### PR TITLE
Fix trader sell effective price calc

### DIFF
--- a/src/plugins/trader/trader.test.ts
+++ b/src/plugins/trader/trader.test.ts
@@ -554,9 +554,9 @@ describe('Trader', () => {
       const amount = 2;
       const feePercent = 1; // 1%
       // Expected cost = (1/100) * 2 * 100 = 2,
-      // Expected effectivePrice = 100 * ((1/100) - 1) = 100 * (-0.99) = -99.
+      // Expected effectivePrice = 100 * (1 - 1/100) = 99.
       const result = trader['processCostAndPrice'](side, price, amount, feePercent);
-      expect(result).toEqual({ effectivePrice: -99, cost: 2 });
+      expect(result).toEqual({ effectivePrice: 99, cost: 2 });
     });
 
     it('should calculate cost and effectivePrice when feePercent is not provided', () => {

--- a/src/plugins/trader/trader.ts
+++ b/src/plugins/trader/trader.ts
@@ -255,8 +255,13 @@ export class Trader extends Plugin {
   private processCostAndPrice(side: Action, price: number, amount: number, feePercent?: number) {
     if (feePercent) {
       const cost = +Big(feePercent).div(100).mul(amount).mul(price);
-      if (side === 'buy') return { effectivePrice: +Big(price).mul(Big(feePercent).div(100).add(1)), cost };
-      else return { effectivePrice: +Big(price).mul(Big(feePercent).div(100).minus(1)), cost };
+      if (side === 'buy')
+        return { effectivePrice: +Big(price).mul(Big(feePercent).div(100).add(1)), cost };
+      else
+        return {
+          effectivePrice: +Big(price).mul(Big(1).minus(Big(feePercent).div(100))),
+          cost,
+        };
     }
     logger.warn('WARNING: exchange did not provide fee information, assuming no fees..');
     return { effectivePrice: price, cost: +Big(price).mul(amount) };


### PR DESCRIPTION
## Summary
- fix calculation of effective price for sell orders
- update Trader tests to match correct sell formula

## Testing
- `bun test` *(fails: Cannot find package dependencies and failing unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_684195a51750832e98816d68a0db4fc5