### PR TITLE
Add MAE metric to performance analyzer

### DIFF
--- a/documentation/plugins/performance-analyzer.md
+++ b/documentation/plugins/performance-analyzer.md
@@ -49,7 +49,23 @@ Here are the metrics reported in the `performanceReport` event:
 | `exposure`                | % of time the strategy was in a trade.                |
 | `downside`                | Measure of downside risk based on losing trades.      |
 | `trades`                  | Number of trades executed.                            |
-| `ratioRoundTrips`         | % of roundtrips that were profitable.                 |
+| `ratioRoundTrips`         | % of roundtrips that were profitable. |
+| `worstMaxAdverseExcursion` | Largest MAE encountered among all roundtrips. |
 | `startTime` / `endTime`   | Start and end timestamps of the session.              |
 | `startPrice` / `endPrice` | Asset price at session start and end.                 |
 | `duration`                | Duration of the session in human-readable format.     |
+
+## Roundtrip Statistics
+
+Each `roundtrip` event carries detailed information about the trade that just closed. Besides the entry and exit information it now reports the **Maximum Adverse Excursion (MAE)**, describing the worst price movement against the position before it was closed.
+
+| Field                 | Description                                                              |
+|-----------------------|--------------------------------------------------------------------------|
+| `entryAt`             | Timestamp when the trade was opened.                                     |
+| `exitAt`              | Timestamp when the trade was closed.                                     |
+| `entryPrice`          | Price at entry.                                                          |
+| `exitPrice`           | Price at exit.                                                           |
+| `pnl`                 | Profit & loss in the configured currency.                                |
+| `profit`              | Profit percentage over the roundtrip.                                    |
+| `duration`            | Time the position was open.                                              |
+| `maxAdverseExcursion` | Largest drawdown from the entry price observed before closing the trade. |

--- a/documentation/plugins/performance-reporter.md
+++ b/documentation/plugins/performance-reporter.md
@@ -46,6 +46,7 @@ Each row in the CSV contains the following metrics:
 | `sharpeRatio`           | Risk-adjusted return metric                                                                     |
 | `expectedDownside`      | Worst-case loss estimate                                                                        |
 | `ratioRoundtrip`        | Ratio of trades that completed a full buy/sell cycle                                            |
+| `worstMae`              | Maximum MAE observed across all roundtrips                                            |
 
 ## Events Emitted
 

--- a/documentation/plugins/telegram.md
+++ b/documentation/plugins/telegram.md
@@ -48,7 +48,7 @@ The **Telegram** plugin listens to a variety of events in order to send notifica
 | `onTradeAborted`       | Sends a message when a trade is aborted due to portfolio constraints.      |
 | `onTradeCanceled`      | Notifies when a pending trade is canceled before execution.                |
 | `onTradeErrored`       | Reports an error that occurred during trade execution.                     |
-| `onRoundtrip`          | Sends a summary when a roundtrip (buy → sell) is completed.                |
+| `onRoundtrip`          | Sends a summary when a roundtrip (buy → sell) is completed, including MAE.                |
 
 ## Plugin Limitations
 

--- a/src/models/types/roundtrip.types.ts
+++ b/src/models/types/roundtrip.types.ts
@@ -7,6 +7,11 @@ export type RoundTrip = {
   exitPrice: number;
   exitBalance: number;
   duration: number;
+  /**
+   * Maximum Adverse Excursion (MAE) measured as the largest price drop
+   * from the entry price observed before the roundtrip was closed.
+   */
+  maxAdverseExcursion: number;
   profit: number;
   pnl: number;
 };

--- a/src/plugins/performanceAnalyser/performanceAnalyzer.ts
+++ b/src/plugins/performanceAnalyser/performanceAnalyzer.ts
@@ -25,6 +25,7 @@ export class PerformanceAnalyzer extends Plugin {
   private riskFreeReturn: number;
   private roundTrip: SingleRoundTrip;
   private roundTrips: RoundTrip[];
+  private maxAdverseExcursion: number;
   private start: Start;
   private startPrice: number;
   private trades: number;
@@ -46,6 +47,7 @@ export class PerformanceAnalyzer extends Plugin {
     this.riskFreeReturn = riskFreeReturn ?? 1;
     this.roundTrip = { id: 0, entry: null, exit: null };
     this.roundTrips = [];
+    this.maxAdverseExcursion = 0;
     this.start = { balance: 0 };
     this.startPrice = 0;
     this.trades = 0;
@@ -113,6 +115,7 @@ export class PerformanceAnalyzer extends Plugin {
         price: trade.price,
         total: +Big(trade.portfolio.asset).mul(trade.price).plus(trade.portfolio.currency),
       };
+      this.maxAdverseExcursion = 0;
       this.openRoundTrip = true;
     } else if (trade.action === 'sell') {
       this.roundTrip.exit = {
@@ -142,11 +145,15 @@ export class PerformanceAnalyzer extends Plugin {
 
       pnl: +Big(this.roundTrip.exit.total).minus(this.roundTrip.entry.total),
       profit: +Big(100).mul(this.roundTrip.exit.total).div(this.roundTrip.entry.total).minus(100),
+      maxAdverseExcursion: this.maxAdverseExcursion,
 
       duration: differenceInMilliseconds(this.roundTrip.exit.date, this.roundTrip.entry.date),
     };
 
     this.roundTrips[this.roundTrip.id] = roundtrip;
+
+    // reset MAE tracker for next roundtrip
+    this.maxAdverseExcursion = 0;
 
     logRoundtrip(roundtrip, this.currency, this.enableConsoleTable);
 
@@ -195,6 +202,11 @@ export class PerformanceAnalyzer extends Plugin {
 
     const market = +Big(this.endPrice).minus(this.startPrice).div(this.startPrice).mul(100);
 
+    const worstMaxAdverseExcursion = Math.max(
+      0,
+      ...this.roundTrips.map(r => r.maxAdverseExcursion),
+    );
+
     const report: Report = {
       alpha: +Big(relativeProfit).minus(market),
       balance: this.balance,
@@ -205,6 +217,7 @@ export class PerformanceAnalyzer extends Plugin {
       market,
       profit,
       ratioRoundTrips,
+      worstMaxAdverseExcursion,
       relativeProfit: relativeProfit,
       relativeYearlyProfit,
       sharpe,
@@ -240,7 +253,15 @@ export class PerformanceAnalyzer extends Plugin {
 
       this.endPrice = candle.close;
 
-      if (this.openRoundTrip) this.emitRoundtripUpdate();
+      if (this.openRoundTrip) {
+        if (this.roundTrip.entry) {
+          const adverse = Big(this.roundTrip.entry.price).minus(candle.close);
+          if (adverse.gt(this.maxAdverseExcursion)) {
+            this.maxAdverseExcursion = +adverse;
+          }
+        }
+        this.emitRoundtripUpdate();
+      }
     } else {
       this.warmupCandle = candle;
     }

--- a/src/plugins/performanceAnalyser/performanceAnalyzer.types.ts
+++ b/src/plugins/performanceAnalyser/performanceAnalyzer.types.ts
@@ -45,5 +45,9 @@ export type Report = {
   sharpe: number;
   downside: number;
   ratioRoundTrips: number;
+  /**
+   * Maximum adverse excursion observed across all closed roundtrips.
+   */
+  worstMaxAdverseExcursion: number;
   alpha: number;
 };

--- a/src/plugins/performanceAnalyser/performanceAnalyzer.utils.ts
+++ b/src/plugins/performanceAnalyser/performanceAnalyzer.utils.ts
@@ -17,6 +17,7 @@ export const logRoundtrip = (roundTrip: RoundTrip, currency: string, enableConso
       exposedDuration: formatDuration(intervalToDuration({ start: 0, end: roundTrip.duration })),
       'P&L': `${formater.format(roundTrip.pnl)} ${currency}`,
       profit: `${+Big(roundTrip.profit).round(2, Big.roundDown)}%`,
+      MAE: `${formater.format(roundTrip.maxAdverseExcursion)} ${currency}`,
     });
   }
   info('performance analyzer', roundTrip);
@@ -44,6 +45,7 @@ export const logFinalize = (report: Report, currency: string, enableConsoleTable
       sharpeRatio: report.sharpe,
       expectedDownside: `${+Big(report.downside).round(2, Big.roundDown)}%`,
       ratioRoundtrip: `${+Big(report.ratioRoundTrips).round(2, Big.roundDown)}%`,
+      worstMAE: `${formater.format(report.worstMaxAdverseExcursion)} ${currency}`,
     });
   }
   info('performance analyzer', report);

--- a/src/plugins/performanceReporter/performanceReporter.test.ts
+++ b/src/plugins/performanceReporter/performanceReporter.test.ts
@@ -24,7 +24,7 @@ vi.mock('@services/configuration/configuration', () => ({
 }));
 
 const HEADER =
-  'id;pair;start time;end time;duration;exposure;start price;end price;market;alpha;yearly profit;total trades;original balance;current balance;sharpe ratio;expected downside;ratio roundtrip\n';
+  'id;pair;start time;end time;duration;exposure;start price;end price;market;alpha;yearly profit;total trades;original balance;current balance;sharpe ratio;expected downside;ratio roundtrip;worst mae\n';
 
 const baseConfig = {
   name: 'PerformanceReporter',
@@ -49,6 +49,7 @@ const sampleReport = {
   sharpe: 1.25,
   downside: 0.08,
   ratioRoundTrips: 0.9,
+  worstMaxAdverseExcursion: 0,
 };
 
 // ---------------------------------------------------------------------------
@@ -114,6 +115,7 @@ describe('PerformanceReporter', () => {
           '1.25',
           '0.08%',
           '0.9%',
+          '0',
         ].join(';') + '\n';
 
       expect(fs.appendFileSync).toHaveBeenCalledWith(expectedPath, expectedLine, 'utf8');

--- a/src/plugins/performanceReporter/performanceReporter.ts
+++ b/src/plugins/performanceReporter/performanceReporter.ts
@@ -13,7 +13,7 @@ export class PerformanceReporter extends Plugin {
   private readonly formater: Intl.NumberFormat;
   private readonly filePath: string;
   private readonly header =
-    'id;pair;start time;end time;duration;exposure;start price;end price;market;alpha;yearly profit;total trades;original balance;current balance;sharpe ratio;expected downside;ratio roundtrip\n';
+    'id;pair;start time;end time;duration;exposure;start price;end price;market;alpha;yearly profit;total trades;original balance;current balance;sharpe ratio;expected downside;ratio roundtrip;worst mae\n';
 
   constructor({ name, filePath, fileName }: PerformanceReporterConfig) {
     super(name);
@@ -41,6 +41,7 @@ export class PerformanceReporter extends Plugin {
         report.sharpe,
         `${+Big(report.downside).round(2, Big.roundDown)}%`,
         `${+Big(report.ratioRoundTrips).round(2, Big.roundDown)}%`,
+        `${this.formater.format(report.worstMaxAdverseExcursion)} ${this.currency}`,
       ].join(';') + '\n';
 
     try {

--- a/src/plugins/telegram/telegram.test.ts
+++ b/src/plugins/telegram/telegram.test.ts
@@ -196,6 +196,7 @@ describe('Telegram', () => {
         entryPrice: 155,
         exitBalance: 200,
         exitPrice: 200,
+        maxAdverseExcursion: 0,
         duration: 3600000, // 1 hour in ms
         entryAt: toTimestamp('2022-01-07T10:00:00Z'),
         exitAt: toTimestamp('2022-01-07T11:00:00Z'),
@@ -210,6 +211,7 @@ describe('Telegram', () => {
         `Exposed Duration: ${formatDuration(intervalToDuration({ start: 0, end: roundtrip.duration }))}`,
         `Profit & Loss: ${formater.format(roundtrip.pnl)} ${telegram['currency']}`,
         `Profit percent: ${+Big(roundtrip.profit).round(2, Big.roundDown)}%`,
+        `MAE: ${formater.format(roundtrip.maxAdverseExcursion)} ${telegram['currency']}`,
       ].join('\n');
       expect(telegram['sendMessage']).toHaveBeenCalledWith('abc', '123', expectedMessage);
     });

--- a/src/plugins/telegram/telegram.ts
+++ b/src/plugins/telegram/telegram.ts
@@ -111,13 +111,14 @@ export class Telegram extends Plugin {
     this.sendMessage(this.token, this.chatId, message);
   }
 
-  public onRoundtrip({ duration, entryAt, exitAt, pnl, profit }: RoundTrip) {
+  public onRoundtrip({ duration, entryAt, exitAt, pnl, profit, maxAdverseExcursion }: RoundTrip) {
     const formater = new Intl.NumberFormat();
     const message = [
       `Roundtrip done from ${toISOString(entryAt)} to ${toISOString(exitAt)}`,
       `Exposed Duration: ${formatDuration(intervalToDuration({ start: 0, end: duration }))}`,
       `Profit & Loss: ${formater.format(pnl)} ${this.currency}`,
       `Profit percent: ${+Big(profit).round(2, Big.roundDown)}%`,
+      `MAE: ${formater.format(maxAdverseExcursion)} ${this.currency}`,
     ].join('\n');
     this.sendMessage(this.token, this.chatId, message);
   }


### PR DESCRIPTION
## Summary
- track max adverse excursion (MAE) for open roundtrips
- expose MAE on roundtrip objects and console table output
- document new field in the performance analyzer docs
- update tests and type definitions for MAE support
- report worst MAE across all roundtrips and update performance reporter, telegram output and docs

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a8a6e9b24832e80e2e721b5602036