### PR TITLE
Add contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+Thanks for your interest in contributing to Gekko 2! This project uses [Bun](https://bun.sh/) for package management and development, along with a few automated checks to keep the codebase consistent.
+
+## Development setup
+
+1. Install dependencies with:
+
+   ```bash
+   bun install
+   ```
+
+2. Run the type checker and linter before committing:
+
+   ```bash
+   bun run type:check
+   bun run lint
+   ```
+
+## Style and lint rules
+
+- **ESLint** enforces our coding style. Run `bun run lint` to automatically fix problems.
+- **Prettier** formats the code. Run `bun run format` or `bun run format:check` to verify formatting.
+- Commit messages must follow the **Conventional Commits** specification. `commitlint` checks this automatically via a Husky hook.
+
+## Running tests
+
+Execute the full test suite with coverage using:
+
+```bash
+bun run test:coverage
+```
+
+Unit tests are powered by [Vitest](https://vitest.dev/).
+
+For more details on our workflow, see the Husky hooks in `.husky/` which run type checks, lint-staged, and tests on each commit and push.

--- a/README.md
+++ b/README.md
@@ -57,3 +57,4 @@ _Use Gekko 2 at your own risk._
   - [TMA](./documentation/strategies/tma.md)
 
 This project adheres to a [Code of Conduct](./CODE_OF_CONDUCT.md).
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for development guidelines.


### PR DESCRIPTION
## Summary
- document dev setup, linting rules, commit message conventions, and tests in `CONTRIBUTING.md`
- link the contributing guide from `README.md`

## Testing
- `bun run test:coverage` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684acd575d40832ea618d3e88391e0d2