### PR TITLE
Fix commit lint for shallow clones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,13 @@ jobs:
 
       - name: Check commit messages
         if: ${{ github.event_name == 'pull_request' }}
-        run: bun run commit:check
+        run: |
+          if git rev-parse HEAD~10 >/dev/null 2>&1; then
+            FROM="HEAD~10"
+          else
+            FROM=$(git rev-list --max-parents=0 HEAD)
+          fi
+          bunx commitlint --from="$FROM"
 
       - name: Check formatting
         run: bun run format:check


### PR DESCRIPTION
## Summary
- remove helper script and revert `package.json`
- inline commit lint range logic directly in CI workflow

## Testing
- `bun run commit:check` *(fails: subject may not be empty)*
- `bun run lint:check`
- `bun run type:check`
- `bun run test:coverage`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_684ae83dc710832ebbfe65fecbf0d5db