### PR TITLE
feat: express MAE metrics as percentages

### DIFF
--- a/documentation/plugins/performance-analyzer.md
+++ b/documentation/plugins/performance-analyzer.md
@@ -36,36 +36,36 @@ The **PerformanceAnalyzer** plugin emits a number of events that are used to tra
 
 Here are the metrics reported in the `performanceReport` event:
 
-| Metric                     | Description                                           |
-|----------------------------|-------------------------------------------------------|
-| `balance`                  | Current portfolio balance in the configured currency. |
-| `profit`                   | Absolute profit since the start of the session.       |
-| `relativeProfit`           | Relative profit in percent since the start.           |
-| `yearlyProfit`             | Projected yearly profit in absolute terms.            |
-| `relativeYearlyProfit`     | Projected yearly profit in percent.                   |
-| `market`                   | Market movement (start price vs end price) in percent.|
-| `alpha`                    | Strategy outperformance vs market.                    |
-| `sharpe`                   | Sharpe ratio based on return volatility.              |
-| `exposure`                 | % of time the strategy was in a trade.                |
-| `downside`                 | Measure of downside risk based on losing trades.      |
-| `trades`                   | Number of trades executed.                            |
-| `ratioRoundTrips`          | % of roundtrips that were profitable.                 |
-| `worstMaxAdverseExcursion` | Largest MAE encountered among all roundtrips.         |
-| `startTime` / `endTime`    | Start and end timestamps of the session.              |
-| `startPrice` / `endPrice`  | Asset price at session start and end.                 |
-| `duration`                 | Duration of the session in human-readable format.     |
+| Metric                     | Description                                                |
+|----------------------------|------------------------------------------------------------|
+| `balance`                  | Current portfolio balance in the configured currency.      |
+| `profit`                   | Absolute profit since the start of the session.            |
+| `relativeProfit`           | Relative profit in percent since the start.                |
+| `yearlyProfit`             | Projected yearly profit in absolute terms.                 |
+| `relativeYearlyProfit`     | Projected yearly profit in percent.                        |
+| `market`                   | Market movement (start price vs end price) in percent.     |
+| `alpha`                    | Strategy outperformance vs market.                         |
+| `sharpe`                   | Sharpe ratio based on return volatility.                   |
+| `exposure`                 | % of time the strategy was in a trade.                     |
+| `downside`                 | Measure of downside risk based on losing trades.           |
+| `trades`                   | Number of trades executed.                                 |
+| `ratioRoundTrips`          | % of roundtrips that were profitable.                      |
+| `worstMaxAdverseExcursion` | Largest MAE encountered among all roundtrips (percentage). |
+| `startTime` / `endTime`    | Start and end timestamps of the session.                   |
+| `startPrice` / `endPrice`  | Asset price at session start and end.                      |
+| `duration`                 | Duration of the session in human-readable format.          |
 
 ## Roundtrip Statistics
 
 Each `roundtrip` event carries detailed information about the trade that just closed.
 
-| Field                 | Description                                                              |
-|-----------------------|--------------------------------------------------------------------------|
-| `entryAt`             | Timestamp when the trade was opened.                                     |
-| `exitAt`              | Timestamp when the trade was closed.                                     |
-| `entryPrice`          | Price at entry.                                                          |
-| `exitPrice`           | Price at exit.                                                           |
-| `pnl`                 | Profit & loss in the configured currency.                                |
-| `profit`              | Profit percentage over the roundtrip.                                    |
-| `duration`            | Time the position was open.                                              |
-| `maxAdverseExcursion` | Largest drawdown from the entry price observed before closing the trade. |
+| Field                 | Description                                                                           |
+|-----------------------|---------------------------------------------------------------------------------------|
+| `entryAt`             | Timestamp when the trade was opened.                                                  |
+| `exitAt`              | Timestamp when the trade was closed.                                                  |
+| `entryPrice`          | Price at entry.                                                                       |
+| `exitPrice`           | Price at exit.                                                                        |
+| `pnl`                 | Profit & loss in the configured currency.                                             |
+| `profit`              | Profit percentage over the roundtrip.                                                 |
+| `duration`            | Time the position was open.                                                           |
+| `maxAdverseExcursion` | Largest drawdown from the entry price observed before closing the trade (percentage). |

--- a/documentation/plugins/performance-reporter.md
+++ b/documentation/plugins/performance-reporter.md
@@ -46,7 +46,7 @@ Each row in the CSV contains the following metrics:
 | `sharpeRatio`           | Risk-adjusted return metric                                                                     |
 | `expectedDownside`      | Worst-case loss estimate                                                                        |
 | `ratioRoundtrip`        | Ratio of trades that completed a full buy/sell cycle                                            |
-| `worstMae`              | Maximum MAE observed across all roundtrips                                                      |
+| `worstMae`              | Maximum MAE observed across all roundtrips (percentage)                                         |
 
 ## Events Emitted
 

--- a/src/models/types/roundtrip.types.ts
+++ b/src/models/types/roundtrip.types.ts
@@ -8,8 +8,9 @@ export type RoundTrip = {
   exitBalance: number;
   duration: number;
   /**
-   * Maximum Adverse Excursion (MAE) measured as the largest price drop
-   * from the entry price observed before the roundtrip was closed.
+   * Maximum Adverse Excursion (MAE) measured as the largest drop from
+   * the entry price observed before the roundtrip was closed.
+   * Expressed as a percentage.
    */
   maxAdverseExcursion: number;
   profit: number;

--- a/src/plugins/performanceAnalyser/performanceAnalyzer.ts
+++ b/src/plugins/performanceAnalyser/performanceAnalyzer.ts
@@ -252,7 +252,7 @@ export class PerformanceAnalyzer extends Plugin {
 
       if (this.openRoundTrip) {
         if (this.roundTrip.entry) {
-          const adverse = +Big(this.roundTrip.entry.price).minus(candle.close);
+          const adverse = +Big(this.roundTrip.entry.price).minus(candle.close).div(this.roundTrip.entry.price).mul(100);
           if (adverse > this.maxAdverseExcursion) this.maxAdverseExcursion = adverse;
         }
         this.emitRoundtripUpdate();

--- a/src/plugins/performanceAnalyser/performanceAnalyzer.types.ts
+++ b/src/plugins/performanceAnalyser/performanceAnalyzer.types.ts
@@ -45,7 +45,10 @@ export type Report = {
   sharpe: number;
   downside: number;
   ratioRoundTrips: number;
-  /** Maximum adverse excursion observed across all closed roundtrips. */
+  /**
+   * Maximum adverse excursion observed across all closed roundtrips.
+   * Expressed as a percentage.
+   */
   worstMaxAdverseExcursion: number;
   alpha: number;
 };

--- a/src/plugins/performanceAnalyser/performanceAnalyzer.utils.ts
+++ b/src/plugins/performanceAnalyser/performanceAnalyzer.utils.ts
@@ -17,7 +17,7 @@ export const logRoundtrip = (roundTrip: RoundTrip, currency: string, enableConso
       exposedDuration: formatDuration(intervalToDuration({ start: 0, end: roundTrip.duration })),
       'P&L': `${formater.format(roundTrip.pnl)} ${currency}`,
       profit: `${+Big(roundTrip.profit).round(2, Big.roundDown)}%`,
-      MAE: `${formater.format(roundTrip.maxAdverseExcursion)} ${currency}`,
+      MAE: `${+Big(roundTrip.maxAdverseExcursion).round(2, Big.roundDown)}%`,
     });
   }
   info('performance analyzer', roundTrip);
@@ -45,7 +45,7 @@ export const logFinalize = (report: Report, currency: string, enableConsoleTable
       sharpeRatio: report.sharpe,
       expectedDownside: `${+Big(report.downside).round(2, Big.roundDown)}%`,
       ratioRoundtrip: `${+Big(report.ratioRoundTrips).round(2, Big.roundDown)}%`,
-      worstMAE: `${formater.format(report.worstMaxAdverseExcursion)} ${currency}`,
+      worstMAE: `${+Big(report.worstMaxAdverseExcursion).round(2, Big.roundDown)}%`,
     });
   }
   info('performance analyzer', report);

--- a/src/plugins/performanceReporter/performanceReporter.test.ts
+++ b/src/plugins/performanceReporter/performanceReporter.test.ts
@@ -115,7 +115,7 @@ describe('PerformanceReporter', () => {
           '1.25',
           '0.08%',
           '0.9%',
-          '0 USDT',
+          '0%',
         ].join(';') + '\n';
 
       expect(fs.appendFileSync).toHaveBeenCalledWith(expectedPath, expectedLine, 'utf8');

--- a/src/plugins/performanceReporter/performanceReporter.ts
+++ b/src/plugins/performanceReporter/performanceReporter.ts
@@ -41,7 +41,7 @@ export class PerformanceReporter extends Plugin {
         report.sharpe,
         `${+Big(report.downside).round(2, Big.roundDown)}%`,
         `${+Big(report.ratioRoundTrips).round(2, Big.roundDown)}%`,
-        `${this.formater.format(report.worstMaxAdverseExcursion)} ${this.currency}`,
+        `${+Big(report.worstMaxAdverseExcursion).round(2, Big.roundDown)}%`,
       ].join(';') + '\n';
 
     try {

--- a/src/plugins/telegram/telegram.test.ts
+++ b/src/plugins/telegram/telegram.test.ts
@@ -211,7 +211,7 @@ describe('Telegram', () => {
         `Exposed Duration: ${formatDuration(intervalToDuration({ start: 0, end: roundtrip.duration }))}`,
         `Profit & Loss: ${formater.format(roundtrip.pnl)} ${telegram['currency']}`,
         `Profit percent: ${+Big(roundtrip.profit).round(2, Big.roundDown)}%`,
-        `MAE: ${formater.format(roundtrip.maxAdverseExcursion)} ${telegram['currency']}`,
+        `MAE: ${+Big(roundtrip.maxAdverseExcursion).round(2, Big.roundDown)}%`,
       ].join('\n');
       expect(telegram['sendMessage']).toHaveBeenCalledWith('abc', '123', expectedMessage);
     });

--- a/src/plugins/telegram/telegram.ts
+++ b/src/plugins/telegram/telegram.ts
@@ -118,7 +118,7 @@ export class Telegram extends Plugin {
       `Exposed Duration: ${formatDuration(intervalToDuration({ start: 0, end: duration }))}`,
       `Profit & Loss: ${formater.format(pnl)} ${this.currency}`,
       `Profit percent: ${+Big(profit).round(2, Big.roundDown)}%`,
-      `MAE: ${formater.format(maxAdverseExcursion)} ${this.currency}`,
+      `MAE: ${+Big(maxAdverseExcursion).round(2, Big.roundDown)}%`,
     ].join('\n');
     this.sendMessage(this.token, this.chatId, message);
   }


### PR DESCRIPTION
## Summary
- calculate MAE percentage in performance analyzer
- describe MAE and worst MAE fields as percentages
- show MAE values with a percent sign in console tables, CSV output, and Telegram messages
- adjust related tests
- document that MAE metrics are percentages

## Testing
- `bun run lint:check`
- `bun run type:check`
- `bun run test`
- `bun run format:check`


------
https://chatgpt.com/codex/tasks/task_e_684be78cf354832eb2863f97ec955a05