### PR TITLE
Fix performance analyzer unrealized PnL calculation

### DIFF
--- a/src/plugins/performanceAnalyser/performanceAnalyzer.test.ts
+++ b/src/plugins/performanceAnalyser/performanceAnalyzer.test.ts
@@ -225,7 +225,9 @@ describe('PerformanceAnalyzer', () => {
       analyzer.roundTrip.entry = {
         price: 900,
         date: toTimestamp('2020-01-01T00:00:00Z'),
-        total: 100,
+        total: 1800,
+        asset: 2,
+        currency: 0,
       };
       analyzer.price = 1000;
       analyzer.dates.end = toTimestamp('2020-01-01T00:10:00Z');
@@ -234,8 +236,8 @@ describe('PerformanceAnalyzer', () => {
       expect(deferredEmitSpy).toHaveBeenCalledExactlyOnceWith(ROUNDTRIP_UPDATE_EVENT, {
         at: toTimestamp('2020-01-01T00:10:00Z'),
         duration: 10 * 60 * 1000,
-        uPnl: 100,
-        uProfit: 100,
+        uPnl: 200,
+        uProfit: 11.11111111111111,
       });
     });
   });
@@ -264,6 +266,8 @@ describe('PerformanceAnalyzer', () => {
         date: trade.date,
         price: trade.price,
         total: 200,
+        asset: trade.portfolio.asset,
+        currency: trade.portfolio.currency,
       });
     });
     it('should open a round trip', () => {
@@ -281,6 +285,8 @@ describe('PerformanceAnalyzer', () => {
         date: toTimestamp('2020-01-01T00:00:00Z'),
         price: 100,
         total: 200,
+        asset: 0,
+        currency: 200,
       };
       const trade = {
         action: 'buy',
@@ -312,6 +318,8 @@ describe('PerformanceAnalyzer', () => {
         date: sellTrade.date,
         price: sellTrade.price,
         total: sellTrade.portfolio.currency,
+        asset: sellTrade.portfolio.asset,
+        currency: sellTrade.portfolio.currency,
       });
     });
     it('should close a round trip', () => {

--- a/src/plugins/performanceAnalyser/performanceAnalyzer.ts
+++ b/src/plugins/performanceAnalyser/performanceAnalyzer.ts
@@ -91,7 +91,10 @@ export class PerformanceAnalyzer extends Plugin {
   // --- BEGIN INTERNALS ---
   private emitRoundtripUpdate(): void {
     if (this.roundTrip.entry) {
-      const uPnl = Big(this.price).minus(this.roundTrip.entry.price);
+      const qty = this.roundTrip.entry.asset;
+      const currency = this.roundTrip.entry.currency;
+      const currentValue = Big(this.price).mul(qty).plus(currency);
+      const uPnl = currentValue.minus(this.roundTrip.entry.total);
       this.deferredEmit(ROUNDTRIP_UPDATE_EVENT, {
         at: this.dates.end,
         duration: differenceInMilliseconds(this.dates.end, this.roundTrip.entry.date),
@@ -114,6 +117,8 @@ export class PerformanceAnalyzer extends Plugin {
         date: trade.date,
         price: trade.price,
         total: +Big(trade.portfolio.asset).mul(trade.price).plus(trade.portfolio.currency),
+        asset: trade.portfolio.asset,
+        currency: trade.portfolio.currency,
       };
       this.maxAdverseExcursion = 0;
       this.openRoundTrip = true;
@@ -122,6 +127,8 @@ export class PerformanceAnalyzer extends Plugin {
         date: trade.date,
         price: trade.price,
         total: +Big(trade.portfolio.asset).mul(trade.price).plus(trade.portfolio.currency),
+        asset: trade.portfolio.asset,
+        currency: trade.portfolio.currency,
       };
       this.openRoundTrip = false;
 

--- a/src/plugins/performanceAnalyser/performanceAnalyzer.types.ts
+++ b/src/plugins/performanceAnalyser/performanceAnalyzer.types.ts
@@ -25,6 +25,8 @@ export type RoundTripData = {
   price: number;
   date: number;
   total: number;
+  asset: number;
+  currency: number;
 };
 
 export type Report = {


### PR DESCRIPTION
## Summary
- compute unrealized PnL using position size and remaining currency
- track asset & currency for roundtrip entry/exit
- update tests to cover multi-quantity positions

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3c59d6ac832eb5d483b26cb66c92