### PR TITLE
Handle zero volatility in sharpe

### DIFF
--- a/src/plugins/performanceAnalyser/performanceAnalyzer.test.ts
+++ b/src/plugins/performanceAnalyser/performanceAnalyzer.test.ts
@@ -573,5 +573,48 @@ describe('PerformanceAnalyzer', () => {
 
       expect(report?.worstMaxAdverseExcursion).toBe(12);
     });
+
+    it('should set sharpe to 0 when there is no volatility', () => {
+      analyzer.roundTrips = [
+        {
+          id: 1,
+          profit: 2,
+          pnl: 0,
+          maxAdverseExcursion: 0,
+          entryAt: 0,
+          entryPrice: 0,
+          entryBalance: 0,
+          exitAt: 0,
+          exitPrice: 0,
+          exitBalance: 0,
+          duration: 0,
+        },
+        {
+          id: 2,
+          profit: 2,
+          pnl: 0,
+          maxAdverseExcursion: 0,
+          entryAt: 0,
+          entryPrice: 0,
+          entryBalance: 0,
+          exitAt: 0,
+          exitPrice: 0,
+          exitBalance: 0,
+          duration: 0,
+        },
+      ];
+
+      const report = analyzer.calculateReportStatistics();
+
+      expect(report?.sharpe).toBe(0);
+    });
+
+    it('should set sharpe to 0 when there are no roundtrips', () => {
+      analyzer.roundTrips = [];
+
+      const report = analyzer.calculateReportStatistics();
+
+      expect(report?.sharpe).toBe(0);
+    });
   });
 });

--- a/src/plugins/performanceAnalyser/performanceAnalyzer.ts
+++ b/src/plugins/performanceAnalyser/performanceAnalyzer.ts
@@ -196,9 +196,11 @@ export class PerformanceAnalyzer extends Plugin {
 
     const percentExposure = +Big(this.exposure).div(differenceInMilliseconds(this.dates.end, this.dates.start));
 
-    const sharpe = +Big(relativeYearlyProfit)
-      .minus(this.riskFreeReturn)
-      .div(stdev(this.roundTrips.map(r => r.profit)) || 1);
+    const volatility = stdev(this.roundTrips.map(r => r.profit));
+    const sharpe =
+      !volatility || Number.isNaN(volatility)
+        ? 0
+        : +Big(relativeYearlyProfit).minus(this.riskFreeReturn).div(volatility);
 
     const tradeCount = this.trades > 2 ? this.trades - 2 : 1;
     const downsideLosses = this.losses.map(r => r.profit);


### PR DESCRIPTION
## Summary
- guard Sharpe ratio computation against zero or NaN volatility
- test Sharpe ratio when volatility is 0 or missing

## Testing
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_684c51ddf1a4832e8dbc8af650fe49a0