### PR TITLE
Fix ratioRoundTrips fallback

### DIFF
--- a/documentation/plugins/performance-analyzer.md
+++ b/documentation/plugins/performance-analyzer.md
@@ -36,24 +36,24 @@ The **PerformanceAnalyzer** plugin emits a number of events that are used to tra
 
 Here are the metrics reported in the `performanceReport` event:
 
-| Metric                     | Description                                                |
-|----------------------------|------------------------------------------------------------|
-| `balance`                  | Current portfolio balance in the configured currency.      |
-| `profit`                   | Absolute profit since the start of the session.            |
-| `relativeProfit`           | Relative profit in percent since the start.                |
-| `yearlyProfit`             | Projected yearly profit in absolute terms.                 |
-| `relativeYearlyProfit`     | Projected yearly profit in percent.                        |
-| `market`                   | Market movement (start price vs end price) in percent.     |
-| `alpha`                    | Strategy outperformance vs market.                         |
-| `sharpe`                   | Sharpe ratio based on return volatility.                   |
-| `exposure`                 | % of time the strategy was in a trade.                     |
-| `downside`                 | Measure of downside risk based on losing trades.           |
-| `trades`                   | Number of trades executed.                                 |
-| `ratioRoundTrips`          | % of roundtrips that were profitable.                      |
-| `worstMaxAdverseExcursion` | Largest MAE encountered among all roundtrips (percentage). |
-| `startTime` / `endTime`    | Start and end timestamps of the session.                   |
-| `startPrice` / `endPrice`  | Asset price at session start and end.                      |
-| `duration`                 | Duration of the session in human-readable format.          |
+| Metric                     | Description                                                                        |
+|----------------------------|------------------------------------------------------------                        |
+| `balance`                  | Current portfolio balance in the configured currency.                              |
+| `profit`                   | Absolute profit since the start of the session.                                    |
+| `relativeProfit`           | Relative profit in percent since the start.                                        |
+| `yearlyProfit`             | Projected yearly profit in absolute terms.                                         |
+| `relativeYearlyProfit`     | Projected yearly profit in percent.                                                |
+| `market`                   | Market movement (start price vs end price) in percent.                             |
+| `alpha`                    | Strategy outperformance vs market.                                                 |
+| `sharpe`                   | Sharpe ratio based on return volatility.                                           |
+| `exposure`                 | % of time the strategy was in a trade.                                             |
+| `downside`                 | Measure of downside risk based on losing trades.                                   |
+| `trades`                   | Number of trades executed.                                                         |
+| `ratioRoundTrips`          | % of roundtrips that were profitable. Returns `null` when no roundtrips occurred.  |
+| `worstMaxAdverseExcursion` | Largest MAE encountered among all roundtrips (percentage).                         |
+| `startTime` / `endTime`    | Start and end timestamps of the session.                                           |
+| `startPrice` / `endPrice`  | Asset price at session start and end.                                              |
+| `duration`                 | Duration of the session in human-readable format.                                  |
 
 ## Roundtrip Statistics
 

--- a/src/plugins/performanceAnalyser/performanceAnalyzer.test.ts
+++ b/src/plugins/performanceAnalyser/performanceAnalyzer.test.ts
@@ -557,6 +557,17 @@ describe('PerformanceAnalyzer', () => {
       });
     });
 
+    it('should set ratioRoundTrips to null when no roundtrips exist', () => {
+      analyzer.roundTrips = [];
+      analyzer.losses = [];
+      analyzer.trades = 0;
+      analyzer.exposure = 0;
+
+      const report = analyzer.calculateReportStatistics();
+
+      expect(report?.ratioRoundTrips).toBeNull();
+    });
+
     it('should report the worst MAE across roundtrips', () => {
       analyzer.roundTrips[0].maxAdverseExcursion = 5;
       analyzer.roundTrips[1].maxAdverseExcursion = 12;

--- a/src/plugins/performanceAnalyser/performanceAnalyzer.ts
+++ b/src/plugins/performanceAnalyser/performanceAnalyzer.ts
@@ -198,7 +198,7 @@ export class PerformanceAnalyzer extends Plugin {
     const positiveRoundtrips = this.roundTrips.filter(roundTrip => roundTrip.pnl > 0);
 
     const ratioRoundTrips =
-      this.roundTrips.length > 0 ? +Big(positiveRoundtrips.length).div(this.roundTrips.length).mul(100).round(4) : 100;
+      this.roundTrips.length > 0 ? +Big(positiveRoundtrips.length).div(this.roundTrips.length).mul(100).round(4) : null;
 
     const market = +Big(this.endPrice).minus(this.startPrice).div(this.startPrice).mul(100);
 

--- a/src/plugins/performanceAnalyser/performanceAnalyzer.types.ts
+++ b/src/plugins/performanceAnalyser/performanceAnalyzer.types.ts
@@ -44,7 +44,7 @@ export type Report = {
   exposure: number;
   sharpe: number;
   downside: number;
-  ratioRoundTrips: number;
+  ratioRoundTrips: Nullable<number>;
   /**
    * Maximum adverse excursion observed across all closed roundtrips.
    * Expressed as a percentage.

--- a/src/plugins/performanceAnalyser/performanceAnalyzer.utils.ts
+++ b/src/plugins/performanceAnalyser/performanceAnalyzer.utils.ts
@@ -44,7 +44,8 @@ export const logFinalize = (report: Report, currency: string, enableConsoleTable
       currentbalance: `${formater.format(report.balance)} ${currency}`,
       sharpeRatio: report.sharpe,
       expectedDownside: `${+Big(report.downside).round(2, Big.roundDown)}%`,
-      ratioRoundtrip: `${+Big(report.ratioRoundTrips).round(2, Big.roundDown)}%`,
+      ratioRoundtrip:
+        report.ratioRoundTrips === null ? 'N/A' : `${+Big(report.ratioRoundTrips).round(2, Big.roundDown)}%`,
       worstMAE: `${+Big(report.worstMaxAdverseExcursion).round(2, Big.roundDown)}%`,
     });
   }

--- a/src/plugins/performanceReporter/performanceReporter.ts
+++ b/src/plugins/performanceReporter/performanceReporter.ts
@@ -40,7 +40,7 @@ export class PerformanceReporter extends Plugin {
         `${this.formater.format(report.balance)} ${this.currency}`,
         report.sharpe,
         `${+Big(report.downside).round(2, Big.roundDown)}%`,
-        `${+Big(report.ratioRoundTrips).round(2, Big.roundDown)}%`,
+        report.ratioRoundTrips === null ? 'N/A' : `${+Big(report.ratioRoundTrips).round(2, Big.roundDown)}%`,
         `${+Big(report.worstMaxAdverseExcursion).round(2, Big.roundDown)}%`,
       ].join(';') + '\n';
 


### PR DESCRIPTION
## Summary
- return `null` for `ratioRoundTrips` when no trades were made
- document the new behavior
- show `N/A` in logs when the ratio is missing
- test for the empty roundtrip case

## Testing
- `bun run lint`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_684c3df33d34832e818f4e12ef9172b0