### PR TITLE
Fix advice emission timestamp

### DIFF
--- a/src/plugins/tradingAdvisor/tradingAdvisor.test.ts
+++ b/src/plugins/tradingAdvisor/tradingAdvisor.test.ts
@@ -149,7 +149,7 @@ describe('TradingAdvisor', () => {
       advisor['relayAdvice'](dummyAdvice);
       expect(advisor['deferredEmit']).toHaveBeenCalledExactlyOnceWith(ADVICE_EVENT, {
         ...dummyAdvice,
-        date: addMinutes(candleStart, 1),
+        date: addMinutes(candleStart, 1).getTime(),
       });
     });
   });

--- a/src/plugins/tradingAdvisor/tradingAdvisor.ts
+++ b/src/plugins/tradingAdvisor/tradingAdvisor.ts
@@ -74,7 +74,10 @@ export class TradingAdvisor extends Plugin {
 
   private relayAdvice(advice: Advice) {
     if (!this.candle) throw new PluginError(this.pluginName, 'No candle when relaying advice');
-    this.deferredEmit(ADVICE_EVENT, { ...advice, date: addMinutes(this.candle.start, 1) });
+    this.deferredEmit(ADVICE_EVENT, {
+      ...advice,
+      date: addMinutes(this.candle.start, 1).getTime(),
+    });
   }
   // --- END INTERNALS ---
 


### PR DESCRIPTION
## Summary
- ensure `TradingAdvisor` emits numeric advice timestamps
- adapt tests to expect numeric timestamp

## Testing
- `GEKKO_CONFIG_FILE_PATH=./config/backtest.yml bun run test`

------
https://chatgpt.com/codex/tasks/task_e_684f111c0bc0832e9ecccc426a38e014