### PR TITLE
Update docs to use timeframe

### DIFF
--- a/documentation/modes/backtest.md
+++ b/documentation/modes/backtest.md
@@ -74,7 +74,7 @@ strategy:
 plugins:
   - name: TradingAdvisor
     strategyName: DEMA
-    candleSize: 60
+    timeframe: '1d'
     historySize: 5
 
   - name: PaperTrader

--- a/documentation/modes/realtime.md
+++ b/documentation/modes/realtime.md
@@ -87,7 +87,7 @@ strategy:
 plugins:
   - name: TradingAdvisor
     strategyName: MyAwesomeStrategy
-    candleSize: 1
+    timeframe: '1m'
     historySize: 10
 
   - name: PaperTrader # or Trader for live/sandbox mode

--- a/documentation/plugins/introduction.md
+++ b/documentation/plugins/introduction.md
@@ -17,7 +17,7 @@ To configure a plugin, open your configuration file in a text editor and define 
 plugins:
   - name: 'TradingAdvisor'
     strategyName: 'DEMA'
-    candleSize: 3
+    timeframe: '3m'
     historySize: 3
 
   - name: 'Trader'

--- a/documentation/plugins/trading-advisor.md
+++ b/documentation/plugins/trading-advisor.md
@@ -14,9 +14,13 @@ In your configuration file, under the `plugins` section, you can configure the T
 plugins:
   - name: TradingAdvisor # Must be set to TradingAdvisor.
     strategyName: DEMA # Name of the strategy to run (same as strategy section).
-    candleSize: 60 # The time in minutes each candle represents (e.g., 60 = hourly candles).
+    timeframe: '1d' # Size of the candle to feed into the strategy.
     historySize: 10 # Number of candles the strategy needs before it can start generating advice. (warm-up phase)
 ```
+
+`timeframe` must be one of the following values:
+
+`'1m'`, `'2m'`, `'3m'`, `'5m'`, `'10m'`, `'15m'`, `'30m'`, `'1h'`, `'2h'`, `'4h'`, `'6h'`, `'8h'`, `'12h'`, `'1d'`, `'1w'`, `'1M'`, `'3M'`, `'6M'`, `'1y'`.
 
 ## Events Emitted
 


### PR DESCRIPTION
## Summary
- fix documentation examples to use `timeframe` instead of `candleSize`
- clarify that `timeframe` must be one of the `TIMEFRAMES` values
- list all possible `timeframe` values in Trading Advisor docs

## Testing
- `bun test` *(fails: MissingEnvVarError and other runtime errors)*
- `bun run lint:check`
- `bun run type:check`


------
https://chatgpt.com/codex/tasks/task_e_684f13437aa8832e97a939de671d5b71