### PR TITLE
Remove unused slippage options

### DIFF
--- a/config/backtest-scanner.yml
+++ b/config/backtest-scanner.yml
@@ -25,7 +25,6 @@ plugins:
     historySize: 0
 
   - name: PaperTrader
-    reportInCurrency: true # report the profit in the currency or the asset?
     simulationBalance: # start balance, on what the current balance is compared with
       # these are in the unit types configured in the watcher.
       asset: 0
@@ -34,7 +33,6 @@ plugins:
     feeMaker: 0.15
     feeTaker: 0.25
     feeUsing: maker
-    slippage: 0.05 # how much slippage/spread should Gekko assume per trade?
 
   - name: PerformanceAnalyzer
     riskFreeReturn: 5

--- a/config/backtest.yml
+++ b/config/backtest.yml
@@ -24,7 +24,6 @@ plugins:
     historySize: 0
 
   - name: PaperTrader
-    reportInCurrency: true # report the profit in the currency or the asset?
     simulationBalance: # start balance, on what the current balance is compared with
       # these are in the unit types configured in the watcher.
       asset: 0
@@ -33,7 +32,6 @@ plugins:
     feeMaker: 0.15
     feeTaker: 0.25
     feeUsing: maker
-    slippage: 0.05 # how much slippage/spread should Gekko assume per trade?
 
   - name: PerformanceAnalyzer
     riskFreeReturn: 5

--- a/config/realtime-paper-trader.yml
+++ b/config/realtime-paper-trader.yml
@@ -20,7 +20,6 @@ plugins:
     historySize: 5
 
   - name: PaperTrader
-    reportInCurrency: true # report the profit in the currency or the asset?
     simulationBalance: # start balance, on what the current balance is compared with
       # these are in the unit types configured in the watcher.
       asset: 1
@@ -29,7 +28,6 @@ plugins:
     feeMaker: 0.15
     feeTaker: 0.25
     feeUsing: maker
-    slippage: 0.05 # how much slippage/spread should Gekko assume per trade?
 
   - name: PerformanceAnalyzer
     riskFreeReturn: 5

--- a/documentation/modes/backtest.md
+++ b/documentation/modes/backtest.md
@@ -78,7 +78,6 @@ plugins:
     historySize: 5
 
   - name: PaperTrader
-    reportInCurrency: true # report the profit in the currency or the asset?
     simulationBalance: # start balance, on what the current balance is compared with
       # these are in the unit types configured in the watcher.
       asset: 0
@@ -87,7 +86,6 @@ plugins:
     feeMaker: 0.15
     feeTaker: 0.25
     feeUsing: maker
-    slippage: 0.05 # how much slippage/spread should Gekko assume per trade?
 
   - name: PerformanceAnalyzer
     riskFreeReturn: 5

--- a/documentation/modes/realtime.md
+++ b/documentation/modes/realtime.md
@@ -97,8 +97,6 @@ plugins:
     feeUsing: taker
     feeTaker: 0.1
     feeMaker: 0.05
-    reportInCurrency: true
-    slippage: 0.2
 
   - name: PerformanceAnalyzer
 

--- a/documentation/plugins/paper-trader.md
+++ b/documentation/plugins/paper-trader.md
@@ -8,7 +8,7 @@ This is useful for:
 
 - Testing strategies in live markets without risking real money.
 - Measuring the performance of a strategy in real-time / backtest mode.
-- Comparing different strategy outcomes with configurable fees, slippage, and balances.
+- Comparing different strategy outcomes with configurable fees and balances.
 
 The PaperTrader plugin is fully compatible with triggers such as trailing stops, allowing it to simulate more advanced trading behavior (e.g. exiting long positions with a trailing stop loss).
 
@@ -20,22 +20,16 @@ In your configuration file, under the `plugins` section, you can configure the P
 ```yaml
 plugins:
   - name: PaperTrader # Must be set to PaperTrader
-    reportInCurrency: true # Report profits in the currency (e.g., USDT) instead of the asset
     simulationBalance:
       asset: 1 # Starting simulated asset balance (e.g., BTC)
       currency: 100 # Starting simulated currency balance (e.g., USDT)
     feeMaker: 0.5 # Maker fee in percent (e.g., 0.5%)
     feeTaker: 0.6 # Taker fee in percent (e.g., 0.6%)
     feeUsing: maker # Which fee to apply ("maker" or "taker")
-    slippage: 0.1 # Simulated slippage per trade (in percent)
 
 ```
 
-```
-💡 Note:
-Make sure to set realistic slippage and fees, especially if you plan to use Paper Trader for performance evaluation.
-Unrealistic values can lead to inaccurate results.
-```
+
 
 ## Events Emitted
 

--- a/src/plugins/paperTrader/paperTrader.schema.ts
+++ b/src/plugins/paperTrader/paperTrader.schema.ts
@@ -1,4 +1,4 @@
-import { boolean, number, object, string } from 'yup';
+import { number, object, string } from 'yup';
 
 const simulationBalanceSchema = object({
   asset: number().min(0).required(),
@@ -7,10 +7,8 @@ const simulationBalanceSchema = object({
 
 export const paperTraderSchema = object({
   name: string().required(),
-  reportInCurrency: boolean().required(),
   simulationBalance: simulationBalanceSchema,
   feeMaker: number().positive().required(),
   feeTaker: number().positive().required(),
   feeUsing: string().oneOf(['maker', 'taker']).required(),
-  slippage: number().positive().required(),
 });


### PR DESCRIPTION
## Summary
- drop unused `slippage` and `reportInCurrency` options from PaperTrader
- clean example configs and docs
- update PaperTrader schema

## Testing
- `bun tsc --noEmit`
- `bun test` *(fails: 2923 fail / 22 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684fc8db1b68832e9f6383508baec3f1