### PR TITLE
Fix zero balance event duplication

### DIFF
--- a/src/plugins/paperTrader/paperTrader.test.ts
+++ b/src/plugins/paperTrader/paperTrader.test.ts
@@ -239,7 +239,7 @@ describe('PaperTrader', () => {
     });
     it('should set balance when warmup is done & balance is NOT set', () => {
       trader['warmupCompleted'] = true;
-      trader['balance'] = NaN;
+      trader['balance'] = null;
       trader['price'] = 100;
       trader['exposed'] = false;
       trader['activeStopTrigger'] = undefined;
@@ -251,7 +251,7 @@ describe('PaperTrader', () => {
     });
     it('should emit portfolio change event when warmup is done & balance is NOT set', () => {
       trader['warmupCompleted'] = true;
-      trader['balance'] = NaN;
+      trader['balance'] = null;
       trader['price'] = 100;
       trader['exposed'] = false;
       trader['activeStopTrigger'] = undefined;
@@ -267,7 +267,7 @@ describe('PaperTrader', () => {
     });
     it('should emit portfolio value change event when warmup is done & balance is NOT set', () => {
       trader['warmupCompleted'] = true;
-      trader['balance'] = NaN;
+      trader['balance'] = null;
       trader['price'] = 100;
       trader['exposed'] = false;
       trader['activeStopTrigger'] = undefined;
@@ -307,6 +307,31 @@ describe('PaperTrader', () => {
       trader['processCandle'](candle);
 
       expect(deferredEmitSpy).not.toHaveBeenCalled();
+    });
+    it('should emit portfolio events only once when starting balance is zero', () => {
+      const zeroConfig = {
+        ...papertraderConfig,
+        simulationBalance: { asset: 0, currency: 0 },
+      } as PapertraderConfig;
+      trader = new PaperTrader(zeroConfig);
+      trader['deferredEmit'] = vi.fn();
+      trader['warmupCompleted'] = true;
+      trader['price'] = 100;
+      trader['exposed'] = false;
+      trader['activeStopTrigger'] = undefined;
+      const candle = { close: 150 };
+
+      trader['processCandle'](candle);
+      trader['processCandle'](candle);
+
+      expect(trader['deferredEmit']).toHaveBeenNthCalledWith(1, PORTFOLIO_CHANGE_EVENT, {
+        asset: 0,
+        currency: 0,
+      });
+      expect(trader['deferredEmit']).toHaveBeenNthCalledWith(2, PORTFOLIO_VALUE_CHANGE_EVENT, {
+        balance: 0,
+      });
+      expect(trader['deferredEmit']).toHaveBeenCalledTimes(2);
     });
     it('should update price of active trailing stop if set when warmup is done', () => {
       trader['warmupCompleted'] = true;

--- a/src/plugins/paperTrader/paperTrader.ts
+++ b/src/plugins/paperTrader/paperTrader.ts
@@ -16,6 +16,7 @@ import {
 import { ActiveStopTrigger } from '@plugins/plugin.types';
 import { TrailingStop } from '@services/core/order/trailingStop';
 import { warning } from '@services/logger';
+import { Nullable } from '@models/types/generic.types';
 import Big from 'big.js';
 import { addMinutes } from 'date-fns';
 import { filter } from 'lodash-es';
@@ -24,7 +25,7 @@ import { PapertraderConfig, Position } from './paperTrader.types';
 
 export class PaperTrader extends Plugin {
   private activeStopTrigger?: ActiveStopTrigger;
-  private balance: number;
+  private balance: Nullable<number>;
   private candle?: Candle;
   private exposed: boolean;
   private fee: number;
@@ -40,7 +41,7 @@ export class PaperTrader extends Plugin {
 
   constructor({ feeUsing, feeMaker, feeTaker, simulationBalance }: PapertraderConfig) {
     super(PaperTrader.name);
-    this.balance = NaN;
+    this.balance = null;
     this.rawFee = feeUsing === 'maker' ? feeMaker : feeTaker;
     this.fee = +Big(1).minus(Big(this.rawFee).div(100));
     this.portfolio = { ...simulationBalance };
@@ -247,7 +248,7 @@ export class PaperTrader extends Plugin {
       this.price = candle.close;
       this.candle = candle;
 
-      if (!this.balance) {
+      if (this.balance === null) {
         this.balance = this.getBalance();
         this.emitPortfolioChangeEvent();
         this.emitPortfolioValueChangeEvent();


### PR DESCRIPTION
## Summary
- use `Nullable<number>` for balance
- maintain null initialization for PaperTrader

## Testing
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_684fca2cf034832e806c813ecb54191b