### PR TITLE
Fix JSON config detection

### DIFF
--- a/src/services/configuration/configuration.test.ts
+++ b/src/services/configuration/configuration.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { writeFileSync, unlinkSync } from 'fs';
+import { resolve } from 'path';
+
+const configPath = resolve(__dirname, 'temp-config.json');
+
+const configContent = {
+  showLogo: false,
+  watch: { asset: 'BTC', currency: 'USDT', mode: 'realtime', fillGaps: 'no' },
+  plugins: [{ name: 'PerformanceAnalyzer' }],
+  strategy: { name: 'demo' },
+};
+
+describe('Configuration service', () => {
+  beforeEach(() => {
+    writeFileSync(configPath, JSON.stringify(configContent));
+    process.env.GEKKO_CONFIG_FILE_PATH = configPath;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    unlinkSync(configPath);
+    delete process.env.GEKKO_CONFIG_FILE_PATH;
+  });
+
+  it('loads JSON configuration files', async () => {
+    const { config } = await import('./configuration');
+    expect(config.getWatch().mode).toBe('realtime');
+  });
+});

--- a/src/services/configuration/configuration.ts
+++ b/src/services/configuration/configuration.ts
@@ -14,7 +14,7 @@ class Configuration {
   constructor() {
     const configFilePath = process.env['GEKKO_CONFIG_FILE_PATH'];
     if (!configFilePath) throw new MissingEnvVarError('GEKKO_CONFIG_FILE_PATH');
-    const isJson = configFilePath?.endsWith('json5') || configFilePath?.endsWith('json5');
+    const isJson = configFilePath?.endsWith('json') || configFilePath?.endsWith('json5');
     const isYaml = configFilePath?.endsWith('yml') || configFilePath?.endsWith('yaml');
     const data = readFileSync(configFilePath, 'utf8');
     if (isJson) this.configuration = JSON5.parse(data);


### PR DESCRIPTION
## Summary
- fix extension check for JSON configs in Configuration service
- add regression test loading `.json` configuration files

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fde024034832e92c2945b09f5faec