### PR TITLE
Fix fee percent logic

### DIFF
--- a/src/plugins/trader/trader.test.ts
+++ b/src/plugins/trader/trader.test.ts
@@ -557,6 +557,15 @@ describe('Trader', () => {
       expect(result).toEqual({ effectivePrice: 99, cost: 2 });
     });
 
+    it('should handle a feePercent of 0 correctly', () => {
+      const side = 'buy';
+      const price = 100;
+      const amount = 2;
+      const feePercent = 0;
+      const result = trader['processCostAndPrice'](side, price, amount, feePercent);
+      expect(result).toEqual({ effectivePrice: 100, cost: 0 });
+    });
+
     it('should calculate cost and effectivePrice when feePercent is not provided', () => {
       const side = 'buy'; // side doesn't matter in this branch
       const price = 100;

--- a/src/plugins/trader/trader.ts
+++ b/src/plugins/trader/trader.ts
@@ -25,7 +25,7 @@ import { debug, error, info, warning } from '@services/logger';
 import { toISOString } from '@utils/date/date.utils';
 import { wait } from '@utils/process/process.utils';
 import Big from 'big.js';
-import { bindAll, filter, isEqual } from 'lodash-es';
+import { bindAll, filter, isEqual, isNil } from 'lodash-es';
 import { SYNCHRONIZATION_INTERVAL } from './trader.const';
 import { traderSchema } from './trader.schema';
 
@@ -229,7 +229,7 @@ export class Trader extends Plugin {
   }
 
   private processCostAndPrice(side: Action, price: number, amount: number, feePercent?: number) {
-    if (feePercent) {
+    if (!isNil(feePercent)) {
       const cost = +Big(feePercent).div(100).mul(amount).mul(price);
       if (side === 'buy') return { effectivePrice: +Big(price).mul(Big(feePercent).div(100).add(1)), cost };
       else return { effectivePrice: +Big(price).mul(Big(1).minus(Big(feePercent).div(100))), cost };

--- a/src/utils/date/date.utils.ts
+++ b/src/utils/date/date.utils.ts
@@ -21,7 +21,7 @@ export const resetDateParts = (date?: EpochTimeStamp, parts?: Time[]): EpochTime
     : 0;
 
 export const toISOString = (timestamp?: EpochTimeStamp): string =>
-  !isNil(timestamp) ? new Date(timestamp).toISOString() : 'Unknwon Date';
+  !isNil(timestamp) ? new Date(timestamp).toISOString() : 'Unknown Date';
 
 export const toTimestamp = (iso8601String?: string): EpochTimeStamp => new Date(iso8601String ?? 0).getTime();
 


### PR DESCRIPTION
## Summary
- fix typo in `toISOString`
- handle zero fee percent correctly in trader utility
- test zero-fee case
- ensure fee presence check uses `isNil`

## Testing
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_684fe12836bc832e99dc481b926a01fa