### PR TITLE
Fix async plugin setup and typo

### DIFF
--- a/src/services/core/heart/heart.ts
+++ b/src/services/core/heart/heart.ts
@@ -31,7 +31,7 @@ export class Heart extends EventEmitter {
   }
 
   public stop() {
-    debug('core', 'Stoping heartbeat ticks');
+    debug('core', 'Stopping heartbeat ticks');
     clearInterval(this.timeout);
     this.timeout = undefined;
   }

--- a/src/utils/pipeline/pipeline.utils.ts
+++ b/src/utils/pipeline/pipeline.utils.ts
@@ -61,11 +61,7 @@ const askForDaterange = async () => {
 };
 
 export const initPlugins = async (context: PipelineContext) => {
-  await Promise.all(
-    context.map(pipeline => {
-      pipeline.plugin?.processInitStream();
-    }),
-  );
+  await Promise.all(context.map(pipeline => pipeline.plugin?.processInitStream()));
   return context;
 };
 
@@ -124,16 +120,18 @@ export const checkPluginsDuplicateEvents = async (context: PipelineContext) => {
   return context;
 };
 
-export const checkPluginsDependencies = async (context: PipelineContext) =>
-  each(context, async plugin => {
-    each(plugin.dependencies, async dependency => {
+export const checkPluginsDependencies = async (context: PipelineContext) => {
+  for (const plugin of context) {
+    for (const dependency of plugin.dependencies ?? []) {
       try {
         await import(dependency);
       } catch {
         throw new PluginMissingDependencyError(plugin.name, dependency);
       }
-    });
-  });
+    }
+  }
+  return context;
+};
 
 export const validatePluginsSchema = async (context: PipelineContext) => {
   const parameters = config.getPlugins();


### PR DESCRIPTION
## Summary
- ensure plugin initialization is awaited
- validate plugin dependencies synchronously
- fix typo in heart service log message

## Testing
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_684fe6f86e10832e903d5ce26e842711