### PR TITLE
Update docs for new watch config

### DIFF
--- a/documentation/modes/backtest.md
+++ b/documentation/modes/backtest.md
@@ -35,6 +35,9 @@ watch:
   asset: BTC
   currency: USDT
   mode: backtest
+  timeframe: '1d' # default is '1m'
+  warmup:
+    candleCount: 365 # 0 disables warmup
   daterange:
     start: '2024-01-01T00:00:00.000Z'
     end: '2024-02-01T00:00:00.000Z'
@@ -74,8 +77,6 @@ strategy:
 plugins:
   - name: TradingAdvisor
     strategyName: DEMA
-    timeframe: '1d'
-    historySize: 5
 
   - name: PaperTrader
     simulationBalance: # start balance, on what the current balance is compared with

--- a/documentation/modes/importer.md
+++ b/documentation/modes/importer.md
@@ -37,8 +37,8 @@ watch:
 ```
 
 Available values:
-- no (default): Do not fill missing candles.
-- empty: Fill gaps by inserting synthetic (empty) candles, duplicating the previous candle with adjusted timestamps.
+- no: Do not fill missing candles.
+- empty (default): Fill gaps by inserting synthetic (empty) candles, duplicating the previous candle with adjusted timestamps.
 
 This option ensures smoother datasets and more reliable backtesting when dealing with incomplete data from the exchange.
 

--- a/documentation/modes/realtime.md
+++ b/documentation/modes/realtime.md
@@ -69,6 +69,10 @@ Gekko only executes what your strategy tells it to do.
 - Monitor logs and Telegram messages for unexpected behavior.
 - Ensure you understand the exchange’s fees, limits, and slippage risks.
 
+## Warmup
+
+When `watch.warmup.candleCount` is greater than zero, Gekko will fetch historical candles before starting realtime trading. This allows your strategy and plugins to initialize with sufficient data.
+
 ## Example Realtime Configuration
 
 ```yaml
@@ -76,6 +80,9 @@ watch:
   asset: BTC
   currency: USDT
   mode: realtime
+  timeframe: '1m' # default timeframe is 1m
+  warmup:
+    candleCount: 10
 
 broker:
   name: binance
@@ -87,8 +94,6 @@ strategy:
 plugins:
   - name: TradingAdvisor
     strategyName: MyAwesomeStrategy
-    timeframe: '1m'
-    historySize: 10
 
   - name: PaperTrader # or Trader for live/sandbox mode
     simulationBalance:

--- a/documentation/plugins/introduction.md
+++ b/documentation/plugins/introduction.md
@@ -17,9 +17,7 @@ To configure a plugin, open your configuration file in a text editor and define 
 plugins:
   - name: 'TradingAdvisor'
     strategyName: 'DEMA'
-    timeframe: '3m'
-    historySize: 3
-
+  
   - name: 'Trader'
 
   - name: 'PerformanceAnalyzer'

--- a/documentation/plugins/trading-advisor.md
+++ b/documentation/plugins/trading-advisor.md
@@ -14,11 +14,9 @@ In your configuration file, under the `plugins` section, you can configure the T
 plugins:
   - name: TradingAdvisor # Must be set to TradingAdvisor.
     strategyName: DEMA # Name of the strategy to run (same as strategy section).
-    timeframe: '1d' # Size of the candle to feed into the strategy.
-    historySize: 10 # Number of candles the strategy needs before it can start generating advice. (warm-up phase)
 ```
 
-`timeframe` must be one of the following values:
+The candle `timeframe` and optional warm‑up settings are now defined under the `watch` section. `timeframe` defaults to `'1m'` and must be one of the following values:
 
 `'1m'`, `'2m'`, `'3m'`, `'5m'`, `'10m'`, `'15m'`, `'30m'`, `'1h'`, `'2h'`, `'4h'`, `'6h'`, `'8h'`, `'12h'`, `'1d'`, `'1w'`, `'1M'`, `'3M'`, `'6M'`, `'1y'`.
 


### PR DESCRIPTION
## Description of Changes
- document moving timeframe and warmup to `watch`
- mention fillGaps default change
- update realtime docs with warmup feature

## Related Issues

## Checklist
- [x] Code is formatted using Prettier
- [x] Linting passes (`bun run lint:check`)
- [x] Tests pass (`bun run test`)
- [x] Type checks pass (`bun run type:check`)
- [x] I've added or updated documentation (if applicable)


------
https://chatgpt.com/codex/tasks/task_e_68595446992c832e8161d86823f798e6