### PR TITLE
Fix strategy advice event constant typo

### DIFF
--- a/src/plugins/plugin.const.ts
+++ b/src/plugins/plugin.const.ts
@@ -7,7 +7,7 @@ export const TRADE_ABORTED_EVENT = 'tradeAborted';
 export const TRADE_CANCELED_EVENT = 'tradeCanceled';
 export const TRADE_COMPLETED_EVENT = 'tradeCompleted';
 
-export const STARTEGY_ADVICE_EVENT = 'strategyAdvice';
+export const STRATEGY_ADVICE_EVENT = 'strategyAdvice';
 export const STRATEGY_CANDLE_EVENT = 'strategyTimeframeCandle';
 export const STRATEGY_NOTIFICATION_EVENT = 'strategyNotification';
 export const STRATEGY_UPDATE_EVENT = 'strategyUpdate';

--- a/src/plugins/tradingAdvisor/tradingAdvisor.test.ts
+++ b/src/plugins/tradingAdvisor/tradingAdvisor.test.ts
@@ -8,7 +8,7 @@ import { PluginError } from '../../errors/plugin/plugin.error';
 import { StrategyNotFoundError } from '../../errors/strategy/strategyNotFound.error';
 import { toTimestamp } from '../../utils/date/date.utils';
 import {
-  STARTEGY_ADVICE_EVENT,
+  STRATEGY_ADVICE_EVENT,
   STRATEGY_CANDLE_EVENT,
   STRATEGY_NOTIFICATION_EVENT,
   STRATEGY_UPDATE_EVENT,
@@ -142,11 +142,11 @@ describe('TradingAdvisor', () => {
       expect(() => advisor['relayAdvice'](defaultAdvice)).toThrow(PluginError);
     });
 
-    it('should emit STARTEGY_ADVICE_EVENT in relayAdvice when a candle is set', () => {
+    it('should emit STRATEGY_ADVICE_EVENT in relayAdvice when a candle is set', () => {
       const candleStart = toTimestamp('2025-01-01T00:00:00Z');
       advisor.candle = defaultCandle;
       advisor['relayAdvice'](defaultAdvice);
-      expect(advisor['deferredEmit']).toHaveBeenCalledExactlyOnceWith(STARTEGY_ADVICE_EVENT, {
+      expect(advisor['deferredEmit']).toHaveBeenCalledExactlyOnceWith(STRATEGY_ADVICE_EVENT, {
         ...defaultAdvice,
         date: addMinutes(candleStart, 1).getTime(),
       });

--- a/src/plugins/tradingAdvisor/tradingAdvisor.ts
+++ b/src/plugins/tradingAdvisor/tradingAdvisor.ts
@@ -13,7 +13,7 @@ import { StrategyNames } from '@strategies/strategy.types';
 import { addMinutes } from 'date-fns';
 import { bindAll, filter } from 'lodash-es';
 import {
-  STARTEGY_ADVICE_EVENT,
+  STRATEGY_ADVICE_EVENT,
   STRATEGY_CANDLE_EVENT,
   STRATEGY_NOTIFICATION_EVENT,
   STRATEGY_UPDATE_EVENT,
@@ -55,7 +55,7 @@ export class TradingAdvisor extends Plugin {
   private setUpListeners() {
     this.strategy
       ?.on(STRATEGY_WARMUP_COMPLETED_EVENT, this.relayStrategyWarmupCompleted)
-      .on(STARTEGY_ADVICE_EVENT, this.relayAdvice)
+      .on(STRATEGY_ADVICE_EVENT, this.relayAdvice)
       .on(STRATEGY_UPDATE_EVENT, this.relayStrategyUpdate)
       .on(STRATEGY_NOTIFICATION_EVENT, this.relayStrategyNotification);
   }
@@ -74,7 +74,7 @@ export class TradingAdvisor extends Plugin {
 
   private relayAdvice(advice: Advice) {
     if (!this.candle) throw new PluginError(this.pluginName, 'No candle when relaying advice');
-    this.deferredEmit(STARTEGY_ADVICE_EVENT, {
+    this.deferredEmit(STRATEGY_ADVICE_EVENT, {
       ...advice,
       date: addMinutes(this.candle.start, 1).getTime(),
     });
@@ -111,7 +111,7 @@ export class TradingAdvisor extends Plugin {
       inject: [],
       eventsHandlers: filter(Object.getOwnPropertyNames(TradingAdvisor.prototype), p => p.startsWith('on')),
       eventsEmitted: [
-        STARTEGY_ADVICE_EVENT,
+        STRATEGY_ADVICE_EVENT,
         STRATEGY_CANDLE_EVENT,
         STRATEGY_NOTIFICATION_EVENT,
         STRATEGY_UPDATE_EVENT,

--- a/src/strategies/dema/dema.test.ts
+++ b/src/strategies/dema/dema.test.ts
@@ -1,4 +1,4 @@
-import { STARTEGY_ADVICE_EVENT } from '@plugins/plugin.const';
+import { STRATEGY_ADVICE_EVENT } from '@plugins/plugin.const';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Advice } from '../../models/types/advice.types';
 import { Candle } from '../../models/types/candle.types';
@@ -29,7 +29,7 @@ describe('DEMA Strategy', () => {
     strategy['indicators'] = [dema, sma];
 
     advices = [];
-    strategy['on'](STARTEGY_ADVICE_EVENT, (advice: Advice) => advices.push(advice.recommendation));
+    strategy['on'](STRATEGY_ADVICE_EVENT, (advice: Advice) => advices.push(advice.recommendation));
 
     candle = { start: Date.now(), open: 1, high: 2, low: 0, close: 1, volume: 100 };
     // Bypass warmup if using onNewCandle directly

--- a/src/strategies/macd/macd.test.ts
+++ b/src/strategies/macd/macd.test.ts
@@ -1,4 +1,4 @@
-import { STARTEGY_ADVICE_EVENT } from '@plugins/plugin.const';
+import { STRATEGY_ADVICE_EVENT } from '@plugins/plugin.const';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Advice } from '../../models/types/advice.types';
 import { MACD } from './macd.strategy';
@@ -32,7 +32,7 @@ describe('MACD Strategy', () => {
     strategy['candle'] = { start: Date.now(), open: 1, high: 2, low: 0, close: 1, volume: 100 };
 
     advices = [];
-    strategy['on'](STARTEGY_ADVICE_EVENT, (advice: Advice) => advices.push(advice.recommendation));
+    strategy['on'](STRATEGY_ADVICE_EVENT, (advice: Advice) => advices.push(advice.recommendation));
   });
 
   it('should not emit advice before persistence on uptrend', () => {

--- a/src/strategies/rsi/rsi.test.ts
+++ b/src/strategies/rsi/rsi.test.ts
@@ -1,4 +1,4 @@
-import { STARTEGY_ADVICE_EVENT } from '@plugins/plugin.const';
+import { STRATEGY_ADVICE_EVENT } from '@plugins/plugin.const';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Advice } from '../../models/types/advice.types';
 import { RSI } from './rsi.strategy';
@@ -29,7 +29,7 @@ describe('RSI Strategy', () => {
     strategy['candle'] = { start: Date.now(), open: 1, high: 2, low: 0, close: 1, volume: 100 };
 
     advices = [];
-    strategy['on'](STARTEGY_ADVICE_EVENT, (advice: Advice) => advices.push(advice.recommendation));
+    strategy['on'](STRATEGY_ADVICE_EVENT, (advice: Advice) => advices.push(advice.recommendation));
   });
 
   it('should not emit advice before persistence on high trend', () => {

--- a/src/strategies/strategy.ts
+++ b/src/strategies/strategy.ts
@@ -12,7 +12,7 @@ import { toISOString } from '@utils/date/date.utils';
 import { each, map } from 'lodash-es';
 import EventEmitter from 'node:events';
 import {
-  STARTEGY_ADVICE_EVENT,
+  STRATEGY_ADVICE_EVENT,
   STRATEGY_NOTIFICATION_EVENT,
   STRATEGY_UPDATE_EVENT,
   STRATEGY_WARMUP_COMPLETED_EVENT,
@@ -104,7 +104,7 @@ export abstract class Strategy<T extends StrategyNames> extends EventEmitter {
     this.propogatedAdvices++;
 
     // Timestamp handled in trading advisor
-    this.emit<Partial<Advice>>(STARTEGY_ADVICE_EVENT, {
+    this.emit<Partial<Advice>>(STRATEGY_ADVICE_EVENT, {
       id: `advice-${this.propogatedAdvices}`,
       recommendation: newDirection,
     });

--- a/src/strategies/tma/tma.test.ts
+++ b/src/strategies/tma/tma.test.ts
@@ -1,4 +1,4 @@
-import { STARTEGY_ADVICE_EVENT } from '@plugins/plugin.const';
+import { STRATEGY_ADVICE_EVENT } from '@plugins/plugin.const';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Advice } from '../../models/types/advice.types';
 import { TMA } from './tma.strategy';
@@ -33,7 +33,7 @@ describe('TMA Strategy', () => {
     // Capture emitted advices
     advices = [];
 
-    strategy['on'](STARTEGY_ADVICE_EVENT, (advice: Advice) => advices.push(advice.recommendation));
+    strategy['on'](STRATEGY_ADVICE_EVENT, (advice: Advice) => advices.push(advice.recommendation));
   });
 
   it('should emits long advice when short > medium > long', () => {


### PR DESCRIPTION
## Description of Changes
- fix typo `STRATEGY_ADVICE_EVENT` constant and update imports

## Related Issues

## Checklist
- [ ] Code is formatted using Prettier
- [ ] Linting passes (`bun run lint:check`)
- [ ] Tests pass (`bun run test`)
- [ ] Type checks pass (`bun run type:check`)
- [ ] I've added or updated documentation (if applicable)



------
https://chatgpt.com/codex/tasks/task_e_685c12fe6ff4832e90b0465ef2a00740