### PR TITLE
Add tests for recent fixes

### DIFF
--- a/src/plugins/paperTrader/paperTrader.test.ts
+++ b/src/plugins/paperTrader/paperTrader.test.ts
@@ -130,6 +130,16 @@ describe('PaperTrader', () => {
         feePercent: 0.25,
       });
     });
+
+    it('should ignore advice when portfolio is empty', () => {
+      trader['portfolio'] = { asset: 0, currency: 0 };
+      trader['price'] = 100;
+      const deferredEmitSpy = vi.spyOn(trader as any, 'deferredEmit');
+
+      trader.onStrategyAdvice(defaultAdvice);
+
+      expect(deferredEmitSpy).not.toHaveBeenCalled();
+    });
   });
   describe('processOneMinuteCandle', () => {
     it('should store the candle as warmupCandle during warmup', () => {

--- a/src/plugins/performanceAnalyser/performanceAnalyzer.test.ts
+++ b/src/plugins/performanceAnalyser/performanceAnalyzer.test.ts
@@ -316,6 +316,18 @@ describe('PerformanceAnalyzer', () => {
       expect(analyzer['losses']).toHaveLength(0);
     });
 
+    it('should set profit to 0 when entry balance is 0 to avoid division by zero', () => {
+      analyzer['roundTrip'] = {
+        id: 0,
+        entry: { date: toTimestamp('2020'), price: 0, total: 0, asset: 0, currency: 0 },
+        exit: { date: toTimestamp('2020'), price: 100, total: 100, asset: 0, currency: 100 },
+      };
+
+      analyzer['handleCompletedRoundtrip']();
+
+      expect(first(analyzer['roundTrips'])?.profit).toBe(0);
+    });
+
     it('should track max adverse excursion during a roundtrip', () => {
       analyzer['warmupCompleted'] = true;
 


### PR DESCRIPTION
## Summary
- add regression test for divide by zero protection in performanceAnalyzer
- add regression test for ignoring advice when portfolio is empty

## Testing
- `bun run lint:check`
- `bun run type:check`
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_685e7d00843c832e9f4eac5e383476a2