### PR TITLE
Add HeapStatsMonitor plugin

### DIFF
--- a/documentation/plugins/heap-stats-monitor.md
+++ b/documentation/plugins/heap-stats-monitor.md
@@ -1,12 +1,12 @@
 # HeapStatsMonitor Plugin
 
-The **HeapStatsMonitor** plugin prints memory usage information from Bun's `jsc` engine.
+The **HeapStatsMonitor** plugin records memory usage information from Bun's `jsc` engine.
 It can be useful to monitor your strategy's memory consumption during both realtime
 and backtest runs.
 
-``` 
+```
 💡 Note:
-This plugin is read-only and only logs information to the console.
+This plugin is read-only and only writes to a CSV file.
 ```
 
 ## Configuration
@@ -23,6 +23,8 @@ plugins:
       - extraMemorySize
       - objectCount
       - protectedObjectCount
+    filePath: ./results            # Optional: directory for the CSV file
+    fileName: heap_stats.csv       # Optional: CSV file name
 ```
 
 If `metrics` is omitted, the plugin displays the five values above by default.
@@ -30,7 +32,7 @@ If `metrics` is omitted, the plugin displays the five values above by default.
 ## Events Handled
 
 The plugin listens to the `strategyAdvice` event. Every `interval` advices it will
-call `heapStats()` from `bun:jsc` and display the selected metrics using `console.table`.
+call `heapStats()` from `bun:jsc` and append the selected metrics to a CSV file.
 
 ## Events Emitted
 

--- a/documentation/plugins/heap-stats-monitor.md
+++ b/documentation/plugins/heap-stats-monitor.md
@@ -1,0 +1,37 @@
+# HeapStatsMonitor Plugin
+
+The **HeapStatsMonitor** plugin prints memory usage information from Bun's `jsc` engine.
+It can be useful to monitor your strategy's memory consumption during both realtime
+and backtest runs.
+
+``` 
+💡 Note:
+This plugin is read-only and only logs information to the console.
+```
+
+## Configuration
+
+Add the plugin to the `plugins` section of your configuration file:
+
+```yaml
+plugins:
+  - name: HeapStatsMonitor         # Must be set to "HeapStatsMonitor"
+    interval: 10                   # Optional: log every N advices (default = 1)
+    metrics:                       # Optional: list of metrics to display
+      - heapSize
+      - heapCapacity
+      - extraMemorySize
+      - objectCount
+      - protectedObjectCount
+```
+
+If `metrics` is omitted, the plugin displays the five values above by default.
+
+## Events Handled
+
+The plugin listens to the `strategyAdvice` event. Every `interval` advices it will
+call `heapStats()` from `bun:jsc` and display the selected metrics using `console.table`.
+
+## Events Emitted
+
+HeapStatsMonitor does not emit any events.

--- a/documentation/plugins/introduction.md
+++ b/documentation/plugins/introduction.md
@@ -5,6 +5,7 @@ Gekko currently includes several plugins to extend its functionality:
 - [Candle Writer](./candle-writer.md) – writes candle data to the database.
 - [Paper Trader](./paper-trader.md) – simulates trades using your strategy.
 - [Performance Analyzer](./performance-analyzer.md) – evaluates the performance of your strategy.
+- [HeapStatsMonitor](./heap-stats-monitor.md) – monitors Bun heap usage.
 - [Telegram](./trader.md) – sends trading events to a Telegram chat group.
 - [Trader](./trader.md) – executes advice from the [Trading Advisor](./trading-advisor.md) on a real exchange.
 - [Trading Advisor](./trading-advisor.md) – runs your trading strategy and generates advice.

--- a/src/plugins/heapStatsMonitor/heapStatsMonitor.schema.ts
+++ b/src/plugins/heapStatsMonitor/heapStatsMonitor.schema.ts
@@ -1,0 +1,7 @@
+import { array, number, object, string } from 'yup';
+
+export const heapStatsMonitorSchema = object({
+  name: string().required(),
+  interval: number().positive().integer().default(1),
+  metrics: array().of(string()).optional(),
+});

--- a/src/plugins/heapStatsMonitor/heapStatsMonitor.schema.ts
+++ b/src/plugins/heapStatsMonitor/heapStatsMonitor.schema.ts
@@ -4,4 +4,6 @@ export const heapStatsMonitorSchema = object({
   name: string().required(),
   interval: number().positive().integer().default(1),
   metrics: array().of(string()).optional(),
+  filePath: string().default(process.cwd()),
+  fileName: string().default('heap_stats.csv'),
 });

--- a/src/plugins/heapStatsMonitor/heapStatsMonitor.test.ts
+++ b/src/plugins/heapStatsMonitor/heapStatsMonitor.test.ts
@@ -1,7 +1,17 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import path from 'path';
+import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { heapStats } from 'bun:jsc';
 import { HeapStatsMonitor } from './heapStatsMonitor';
 import { heapStatsMonitorSchema } from './heapStatsMonitor.schema';
+
+vi.mock('fs', () => ({
+  mkdirSync: vi.fn(),
+  existsSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  appendFileSync: vi.fn(),
+  statSync: vi.fn(),
+}));
 
 vi.mock('bun:jsc', () => ({
   heapStats: vi.fn(() => ({
@@ -21,56 +31,72 @@ vi.mock('../../services/configuration/configuration', () => {
   return { config: new Configuration() };
 });
 
+const HEADER = 'heapSize;heapCapacity;extraMemorySize;objectCount;protectedObjectCount\n';
+const baseConfig = { name: 'HeapStatsMonitor', interval: 2, filePath: '/tmp', fileName: 'stats.csv' };
+
 describe('HeapStatsMonitor', () => {
+  const releaseMock = vi.fn();
+  const lockSyncMock = vi.fn(() => releaseMock);
   let monitor: HeapStatsMonitor;
+
   beforeEach(() => {
-    monitor = new HeapStatsMonitor({ name: 'HeapStatsMonitor', interval: 2 });
-    vi.spyOn(console, 'table').mockImplementation(() => undefined);
+    monitor = new HeapStatsMonitor(baseConfig);
+    monitor['setFs']({ lockSync: lockSyncMock });
   });
 
-  afterEach(() => {
-    (console.table as unknown as vi.Mock).mockRestore();
+  describe('#processInit', () => {
+    it('creates missing directories and writes header when file is absent', () => {
+      (fs.existsSync as Mock).mockReturnValue(false);
+      (fs.statSync as Mock).mockReturnValue({ size: 0 });
+
+      monitor['processInit']();
+
+      const expectedPath = path.join(baseConfig.filePath, baseConfig.fileName);
+      expect(fs.mkdirSync).toHaveBeenCalledWith(path.dirname(expectedPath), { recursive: true });
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expectedPath, HEADER, 'utf8');
+      expect(lockSyncMock).toHaveBeenCalled();
+    });
   });
 
-  it('should not log before interval is reached', () => {
-    monitor.onStrategyAdvice();
-    expect(console.table).not.toHaveBeenCalled();
-  });
+  describe('#onStrategyAdvice', () => {
+    it('appends stats to csv when interval is reached', () => {
+      (fs.existsSync as Mock).mockReturnValue(true);
+      (fs.statSync as Mock).mockReturnValue({ size: 10 });
+      monitor['processInit']();
 
-  it('should log heap stats when interval is reached', () => {
-    monitor.onStrategyAdvice();
-    monitor.onStrategyAdvice();
-    expect(console.table).toHaveBeenCalledWith({
-      heapSize: 1,
-      heapCapacity: 2,
-      extraMemorySize: 3,
-      objectCount: 4,
-      protectedObjectCount: 5,
+      monitor.onStrategyAdvice();
+      expect(fs.appendFileSync).not.toHaveBeenCalled();
+
+      monitor.onStrategyAdvice();
+      const expectedPath = path.join(baseConfig.filePath, baseConfig.fileName);
+      const expectedLine = '1;2;3;4;5\n';
+      expect(fs.appendFileSync).toHaveBeenCalledWith(expectedPath, expectedLine, 'utf8');
+      expect(releaseMock).toHaveBeenCalled();
     });
   });
 
   describe('getStaticConfiguration', () => {
     const config = HeapStatsMonitor.getStaticConfiguration();
-    it('should return the correct schema', () => {
+    it('returns the correct schema', () => {
       expect(config.schema).toBe(heapStatsMonitorSchema);
     });
-    it('should return modes equal to ["realtime", "backtest"]', () => {
+    it('returns modes equal to ["realtime", "backtest"]', () => {
       expect(config.modes).toEqual(['realtime', 'backtest']);
     });
-    it('should return dependencies as an empty array', () => {
+    it('returns dependencies as an empty array', () => {
       expect(config.dependencies).toEqual([]);
     });
-    it('should return inject as an empty array', () => {
-      expect(config.inject).toEqual([]);
+    it('returns inject equal to ["fs"]', () => {
+      expect(config.inject).toEqual(['fs']);
     });
-    it('should return eventsHandlers containing all methods starting with "on"', () => {
-      const expectedHandlers = Object.getOwnPropertyNames(HeapStatsMonitor.prototype).filter(p => p.startsWith('on'));
-      expect(config.eventsHandlers).toEqual(expectedHandlers);
+    it('returns eventsHandlers containing all methods starting with "on"', () => {
+      const expected = Object.getOwnPropertyNames(HeapStatsMonitor.prototype).filter(p => p.startsWith('on'));
+      expect(config.eventsHandlers).toEqual(expected);
     });
-    it('should return eventsEmitted as an empty array', () => {
+    it('returns eventsEmitted as an empty array', () => {
       expect(config.eventsEmitted).toEqual([]);
     });
-    it('should return name equal to HeapStatsMonitor.name', () => {
+    it('returns name equal to HeapStatsMonitor.name', () => {
       expect(config.name).toBe(HeapStatsMonitor.name);
     });
   });

--- a/src/plugins/heapStatsMonitor/heapStatsMonitor.test.ts
+++ b/src/plugins/heapStatsMonitor/heapStatsMonitor.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { heapStats } from 'bun:jsc';
+import { HeapStatsMonitor } from './heapStatsMonitor';
+import { heapStatsMonitorSchema } from './heapStatsMonitor.schema';
+
+vi.mock('bun:jsc', () => ({
+  heapStats: vi.fn(() => ({
+    heapSize: 1,
+    heapCapacity: 2,
+    extraMemorySize: 3,
+    objectCount: 4,
+    protectedObjectCount: 5,
+  })),
+}));
+
+vi.mock('../../services/configuration/configuration', () => {
+  const Configuration = vi.fn(() => ({
+    getWatch: vi.fn(() => ({})),
+    getStrategy: vi.fn(() => ({})),
+  }));
+  return { config: new Configuration() };
+});
+
+describe('HeapStatsMonitor', () => {
+  let monitor: HeapStatsMonitor;
+  beforeEach(() => {
+    monitor = new HeapStatsMonitor({ name: 'HeapStatsMonitor', interval: 2 });
+    vi.spyOn(console, 'table').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    (console.table as unknown as vi.Mock).mockRestore();
+  });
+
+  it('should not log before interval is reached', () => {
+    monitor.onStrategyAdvice();
+    expect(console.table).not.toHaveBeenCalled();
+  });
+
+  it('should log heap stats when interval is reached', () => {
+    monitor.onStrategyAdvice();
+    monitor.onStrategyAdvice();
+    expect(console.table).toHaveBeenCalledWith({
+      heapSize: 1,
+      heapCapacity: 2,
+      extraMemorySize: 3,
+      objectCount: 4,
+      protectedObjectCount: 5,
+    });
+  });
+
+  describe('getStaticConfiguration', () => {
+    const config = HeapStatsMonitor.getStaticConfiguration();
+    it('should return the correct schema', () => {
+      expect(config.schema).toBe(heapStatsMonitorSchema);
+    });
+    it('should return modes equal to ["realtime", "backtest"]', () => {
+      expect(config.modes).toEqual(['realtime', 'backtest']);
+    });
+    it('should return dependencies as an empty array', () => {
+      expect(config.dependencies).toEqual([]);
+    });
+    it('should return inject as an empty array', () => {
+      expect(config.inject).toEqual([]);
+    });
+    it('should return eventsHandlers containing all methods starting with "on"', () => {
+      const expectedHandlers = Object.getOwnPropertyNames(HeapStatsMonitor.prototype).filter(p => p.startsWith('on'));
+      expect(config.eventsHandlers).toEqual(expectedHandlers);
+    });
+    it('should return eventsEmitted as an empty array', () => {
+      expect(config.eventsEmitted).toEqual([]);
+    });
+    it('should return name equal to HeapStatsMonitor.name', () => {
+      expect(config.name).toBe(HeapStatsMonitor.name);
+    });
+  });
+});

--- a/src/plugins/heapStatsMonitor/heapStatsMonitor.ts
+++ b/src/plugins/heapStatsMonitor/heapStatsMonitor.ts
@@ -1,0 +1,63 @@
+import { Plugin } from '@plugins/plugin';
+import { heapStats } from 'bun:jsc';
+import { filter } from 'lodash-es';
+import { heapStatsMonitorSchema } from './heapStatsMonitor.schema';
+import { HeapStatsMonitorConfig } from './heapStatsMonitor.types';
+
+type HeapStats = ReturnType<typeof heapStats>;
+
+export class HeapStatsMonitor extends Plugin {
+  private adviceCount: number;
+  private interval: number;
+  private metrics: (keyof HeapStats)[];
+  private readonly defaultMetrics: (keyof HeapStats)[] = [
+    'heapSize',
+    'heapCapacity',
+    'extraMemorySize',
+    'objectCount',
+    'protectedObjectCount',
+  ];
+
+  constructor({ name, interval = 1, metrics }: HeapStatsMonitorConfig) {
+    super(name);
+    this.adviceCount = 0;
+    this.interval = interval;
+    this.metrics = (metrics as (keyof HeapStats)[]) ?? this.defaultMetrics;
+  }
+
+  public onStrategyAdvice() {
+    this.adviceCount++;
+    if (this.adviceCount % this.interval !== 0) return;
+    const stats = heapStats();
+    const table: Record<string, number> = {};
+    for (const m of this.metrics) {
+      table[m] = (stats as any)[m];
+    }
+    // eslint-disable-next-line no-console
+    console.table(table);
+  }
+
+  protected processInit(): void {
+    /* noop */
+  }
+
+  protected processOneMinuteCandle(): void {
+    /* noop */
+  }
+
+  protected processFinalize(): void {
+    /* noop */
+  }
+
+  public static getStaticConfiguration() {
+    return {
+      schema: heapStatsMonitorSchema,
+      modes: ['realtime', 'backtest'],
+      dependencies: [],
+      inject: [],
+      eventsHandlers: filter(Object.getOwnPropertyNames(HeapStatsMonitor.prototype), p => p.startsWith('on')),
+      eventsEmitted: [],
+      name: 'HeapStatsMonitor',
+    } as const;
+  }
+}

--- a/src/plugins/heapStatsMonitor/heapStatsMonitor.ts
+++ b/src/plugins/heapStatsMonitor/heapStatsMonitor.ts
@@ -1,6 +1,9 @@
 import { Plugin } from '@plugins/plugin';
 import { heapStats } from 'bun:jsc';
 import { filter } from 'lodash-es';
+import { appendFileSync, existsSync, mkdirSync, statSync, writeFileSync } from 'fs';
+import path from 'path';
+import { error } from '@services/logger';
 import { heapStatsMonitorSchema } from './heapStatsMonitor.schema';
 import { HeapStatsMonitorConfig } from './heapStatsMonitor.types';
 
@@ -10,6 +13,8 @@ export class HeapStatsMonitor extends Plugin {
   private adviceCount: number;
   private interval: number;
   private metrics: (keyof HeapStats)[];
+  private readonly filePath: string;
+  private readonly header: string;
   private readonly defaultMetrics: (keyof HeapStats)[] = [
     'heapSize',
     'heapCapacity',
@@ -18,27 +23,49 @@ export class HeapStatsMonitor extends Plugin {
     'protectedObjectCount',
   ];
 
-  constructor({ name, interval = 1, metrics }: HeapStatsMonitorConfig) {
+  constructor({ name, interval = 1, metrics, filePath, fileName }: HeapStatsMonitorConfig) {
     super(name);
     this.adviceCount = 0;
     this.interval = interval;
     this.metrics = (metrics as (keyof HeapStats)[]) ?? this.defaultMetrics;
+    this.filePath = path.join(filePath ?? process.cwd(), fileName ?? 'heap_stats.csv');
+    this.header = (this.metrics as string[]).join(';') + '\n';
   }
 
   public onStrategyAdvice() {
     this.adviceCount++;
     if (this.adviceCount % this.interval !== 0) return;
     const stats = heapStats();
-    const table: Record<string, number> = {};
-    for (const m of this.metrics) {
-      table[m] = (stats as any)[m];
+    const line = this.metrics.map(m => String((stats as any)[m])).join(';') + '\n';
+    try {
+      const release = this.getFs().lockSync(this.filePath, { retries: 5 });
+      try {
+        appendFileSync(this.filePath, line, 'utf8');
+      } finally {
+        release();
+      }
+    } catch (err) {
+      error('heap stats monitor', `write error: ${err}`);
     }
-    // eslint-disable-next-line no-console
-    console.table(table);
   }
 
   protected processInit(): void {
-    /* noop */
+    try {
+      mkdirSync(path.dirname(this.filePath), { recursive: true });
+      const needsHeader = !existsSync(this.filePath) || statSync(this.filePath).size === 0;
+      if (needsHeader) {
+        const release = this.getFs().lockSync(this.filePath, { retries: 3 });
+        try {
+          if (!existsSync(this.filePath) || statSync(this.filePath).size === 0) {
+            writeFileSync(this.filePath, this.header, 'utf8');
+          }
+        } finally {
+          release();
+        }
+      }
+    } catch (err) {
+      error('heap stats monitor', `setup error: ${err}`);
+    }
   }
 
   protected processOneMinuteCandle(): void {
@@ -54,7 +81,7 @@ export class HeapStatsMonitor extends Plugin {
       schema: heapStatsMonitorSchema,
       modes: ['realtime', 'backtest'],
       dependencies: [],
-      inject: [],
+      inject: ['fs'],
       eventsHandlers: filter(Object.getOwnPropertyNames(HeapStatsMonitor.prototype), p => p.startsWith('on')),
       eventsEmitted: [],
       name: 'HeapStatsMonitor',

--- a/src/plugins/heapStatsMonitor/heapStatsMonitor.types.ts
+++ b/src/plugins/heapStatsMonitor/heapStatsMonitor.types.ts
@@ -1,0 +1,4 @@
+import Yup from 'yup';
+import { heapStatsMonitorSchema } from './heapStatsMonitor.schema';
+
+export type HeapStatsMonitorConfig = Yup.InferType<typeof heapStatsMonitorSchema>;

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -5,3 +5,4 @@ export * from './performanceReporter/performanceReporter';
 export * from './telegram/telegram';
 export * from './trader/trader';
 export * from './tradingAdvisor/tradingAdvisor';
+export * from './heapStatsMonitor/heapStatsMonitor';


### PR DESCRIPTION
## Summary
- add HeapStatsMonitor plugin to show heap stats from Bun
- document plugin in the plugins section
- list plugin in the plugins introduction
- export plugin
- tests for the new plugin

## Testing
- `bun run format:check`
- `bun run lint:check` *(fails: Script not found "eslint")*
- `bun run type:check` *(fails: Script not found "tsc")*
- `bun run test` *(fails: vitest: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ed35491c4832e806b9fbb757ee19b