### PR TITLE
Add trader sync interval cleanup

### DIFF
--- a/src/plugins/trader/trader.test.ts
+++ b/src/plugins/trader/trader.test.ts
@@ -647,6 +647,17 @@ describe('Trader', () => {
     });
   });
 
+  describe('processFinalize', () => {
+    it('should clear sync interval if it exists', () => {
+      const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
+      trader['syncInterval'] = setInterval(() => {}, 100);
+      const interval = trader['syncInterval'];
+      trader['processFinalize']();
+      expect(clearIntervalSpy).toHaveBeenCalledWith(interval);
+      expect(trader['syncInterval']).toBeUndefined();
+    });
+  });
+
   describe('getStaticConfiguration', () => {
     it('should return a configuration object with schema equal to traderSchema', () => {
       const config = Trader.getStaticConfiguration();

--- a/src/plugins/trader/trader.ts
+++ b/src/plugins/trader/trader.ts
@@ -39,6 +39,8 @@ export class Trader extends Plugin {
   private exposure: number;
   private exposed: boolean;
   private order?: StickyOrder;
+  // Timer controlling periodic synchronization with the exchange.
+  private syncInterval?: Timer;
 
   constructor() {
     super(Trader.name);
@@ -53,7 +55,7 @@ export class Trader extends Plugin {
 
     bindAll(this, ['synchronize']);
 
-    setInterval(this.synchronize, SYNCHRONIZATION_INTERVAL);
+    this.syncInterval = setInterval(this.synchronize, SYNCHRONIZATION_INTERVAL);
   }
 
   private async synchronize() {
@@ -307,7 +309,10 @@ export class Trader extends Plugin {
   }
 
   protected processFinalize(): void {
-    /* noop */
+    if (this.syncInterval) {
+      clearInterval(this.syncInterval);
+      this.syncInterval = undefined;
+    }
   }
 
   public static getStaticConfiguration() {


### PR DESCRIPTION
## Summary
- store sync interval timer in `Trader`
- clear interval on finalize
- test that finalize clears interval
- document timer purpose

## Testing
- `bun run lint`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_685f08e37df0832eb7b7a5b31b3ad629