### PR TITLE
Remove Big.js from indicators

### DIFF
--- a/src/indicators/directionalMovement/adx/adx.indicator.ts
+++ b/src/indicators/directionalMovement/adx/adx.indicator.ts
@@ -1,6 +1,5 @@
 import { Indicator } from '@indicators/indicator';
 import { Candle } from '@models/types/candle.types';
-import Big from 'big.js';
 import { isNil } from 'lodash-es';
 import { DX } from '../dx/dx.indicator';
 
@@ -28,19 +27,16 @@ export class ADX extends Indicator<'ADX'> {
     // Warmup
     if (isNil(dx)) return;
     if (this.age < this.period) {
-      this.sumDX = +Big(this.sumDX).plus(dx);
+      this.sumDX += dx;
       this.age++;
       if (this.age === this.period) {
-        this.result = +Big(this.sumDX).div(this.period);
+        this.result = this.sumDX / this.period;
         this.prevADX = this.result;
       }
       return;
     }
 
-    this.result = +Big(this.prevADX)
-      .times(this.period - 1)
-      .plus(dx)
-      .div(this.period);
+    this.result = (this.prevADX * (this.period - 1) + dx) / this.period;
 
     this.prevADX = this.result;
   }

--- a/src/indicators/directionalMovement/dx/dx.indicator.ts
+++ b/src/indicators/directionalMovement/dx/dx.indicator.ts
@@ -1,6 +1,5 @@
 import { Indicator } from '@indicators/indicator';
 import { Candle } from '@models/types/candle.types';
-import Big from 'big.js';
 import { MinusDI } from '../minusDI/minusDI.indicator';
 import { PlusDI } from '../plusDI/plusDI.indicator';
 
@@ -32,8 +31,8 @@ export class DX extends Indicator<'DX'> {
     const plusDI = this.plusDI.getResult() ?? 0;
 
     // DX = 100 * (abs(minusDI - plusDI) / (minusDI + plusDI))
-    const sumDI = +Big(minusDI).plus(plusDI);
-    this.result = sumDI === 0 ? 0 : +Big(100).times(Big(minusDI).minus(plusDI).abs()).div(sumDI);
+    const sumDI = minusDI + plusDI;
+    this.result = sumDI === 0 ? 0 : (100 * Math.abs(minusDI - plusDI)) / sumDI;
   }
 
   public getResult(): number | null {

--- a/src/indicators/directionalMovement/minusDI/minusDI.indicator.ts
+++ b/src/indicators/directionalMovement/minusDI/minusDI.indicator.ts
@@ -1,7 +1,6 @@
 import { Indicator } from '@indicators/indicator';
 import { TrueRange } from '@indicators/volatility/trueRange/trueRange.indicator';
 import { Candle } from '@models/types/candle.types';
-import Big from 'big.js';
 import { MinusDM } from '../minusDM/minusDM.indicator';
 
 export class MinusDI extends Indicator<'MinusDI'> {
@@ -33,11 +32,11 @@ export class MinusDI extends Indicator<'MinusDI'> {
       return;
     }
 
-    const baseTR = Big(this.prevTR).minus(Big(this.prevTR).div(this.period));
-    const newTR = +baseTR.plus(trueRange);
+    const baseTR = this.prevTR - this.prevTR / this.period;
+    const newTR = baseTR + trueRange;
     const newMinusDM = this.minusDM.getResult() ?? 0;
 
-    this.result = newTR === 0 ? 0 : +Big(100).times(Big(newMinusDM).div(newTR));
+    this.result = newTR === 0 ? 0 : (100 * newMinusDM) / newTR;
     this.prevTR = newTR;
   }
 

--- a/src/indicators/directionalMovement/minusDM/minusDM.indicator.ts
+++ b/src/indicators/directionalMovement/minusDM/minusDM.indicator.ts
@@ -1,6 +1,5 @@
 import { Indicator } from '@indicators/indicator';
 import { Candle } from '@models/types/candle.types';
-import Big from 'big.js';
 
 export class MinusDM extends Indicator<'MinusDM'> {
   private period: number;
@@ -18,8 +17,8 @@ export class MinusDM extends Indicator<'MinusDM'> {
   public onNewCandle(candle: Candle): void {
     const { low, high } = candle;
 
-    const diffP = +Big(high).minus(this.lastCandle?.high ?? high);
-    const diffM = +Big(this.lastCandle?.low ?? low).minus(low);
+    const diffP = high - (this.lastCandle?.high ?? high);
+    const diffM = (this.lastCandle?.low ?? low) - low;
     this.lastCandle = candle;
 
     // Warming up
@@ -30,8 +29,8 @@ export class MinusDM extends Indicator<'MinusDM'> {
       return;
     }
 
-    const base = Big(this.prevMinusDM).minus(Big(this.prevMinusDM).div(this.period));
-    this.prevMinusDM = diffM > 0 && diffM > diffP ? +base.plus(diffM) : +base;
+    const base = this.prevMinusDM - this.prevMinusDM / this.period;
+    this.prevMinusDM = diffM > 0 && diffM > diffP ? base + diffM : base;
     this.result = this.prevMinusDM;
   }
 

--- a/src/indicators/directionalMovement/plusDI/plusDI.indicator.ts
+++ b/src/indicators/directionalMovement/plusDI/plusDI.indicator.ts
@@ -1,6 +1,5 @@
 import { TrueRange } from '@indicators/volatility/trueRange/trueRange.indicator';
 import { Candle } from '@models/types/candle.types';
-import Big from 'big.js';
 import { Indicator } from '../../indicator';
 import { PlusDM } from '../plusDM/plusDM.indicator';
 
@@ -33,11 +32,11 @@ export class PlusDI extends Indicator<'PlusDI'> {
       return;
     }
 
-    const baseTR = Big(this.prevTR).minus(Big(this.prevTR).div(this.period));
-    const newTR = +baseTR.plus(trueRange);
+    const baseTR = this.prevTR - this.prevTR / this.period;
+    const newTR = baseTR + trueRange;
     const newPlusDM = this.plusDM.getResult() ?? 0;
 
-    this.result = newTR === 0 ? 0 : +Big(100).times(Big(newPlusDM).div(newTR));
+    this.result = newTR === 0 ? 0 : (100 * newPlusDM) / newTR;
     this.prevTR = newTR;
   }
 

--- a/src/indicators/directionalMovement/plusDM/plusDM.indicator.ts
+++ b/src/indicators/directionalMovement/plusDM/plusDM.indicator.ts
@@ -1,6 +1,5 @@
 import { Indicator } from '@indicators/indicator';
 import { Candle } from '@models/types/candle.types';
-import Big from 'big.js';
 
 export class PlusDM extends Indicator<'PlusDM'> {
   private period: number;
@@ -18,8 +17,8 @@ export class PlusDM extends Indicator<'PlusDM'> {
   public onNewCandle(candle: Candle): void {
     const { low, high } = candle;
 
-    const diffP = +Big(high).minus(this.lastCandle?.high ?? high);
-    const diffM = +Big(this.lastCandle?.low ?? low).minus(low);
+    const diffP = high - (this.lastCandle?.high ?? high);
+    const diffM = (this.lastCandle?.low ?? low) - low;
     this.lastCandle = candle;
 
     // Warming up
@@ -30,8 +29,8 @@ export class PlusDM extends Indicator<'PlusDM'> {
       return;
     }
 
-    const base = Big(this.prevPlusDM).minus(Big(this.prevPlusDM).div(this.period));
-    this.prevPlusDM = diffP > 0 && diffP > diffM ? +base.plus(diffP) : +base;
+    const base = this.prevPlusDM - this.prevPlusDM / this.period;
+    this.prevPlusDM = diffP > 0 && diffP > diffM ? base + diffP : base;
     this.result = this.prevPlusDM;
   }
 

--- a/src/indicators/momentum/macd/macd.indicator.ts
+++ b/src/indicators/momentum/macd/macd.indicator.ts
@@ -1,6 +1,5 @@
 import { EMA } from '@indicators/movingAverages/ema/ema.indicator';
 import { Candle } from '@models/types/candle.types';
-import Big from 'big.js';
 import { isNil } from 'lodash-es';
 import { Indicator } from '../../indicator';
 
@@ -41,17 +40,17 @@ export class MACD extends Indicator<'MACD'> {
     const slow = this.emaSlow.getResult();
 
     if (isNil(fast) || isNil(slow)) return;
-    const macdLine = Big(fast).minus(slow);
-    this.emaSignal.onNewCandle({ close: +macdLine } as Candle);
+    const macdLine = fast - slow;
+    this.emaSignal.onNewCandle({ close: macdLine } as Candle);
     const signalNum = this.emaSignal.getResult();
 
     if (isNil(signalNum)) return;
-    const hist = macdLine.minus(Big(signalNum));
+    const hist = macdLine - signalNum;
 
     this.result = {
-      macd: +macdLine,
+      macd: macdLine,
       signal: signalNum,
-      hist: +hist,
+      hist,
     };
   }
 

--- a/src/indicators/momentum/psar/psar.indicator.ts
+++ b/src/indicators/momentum/psar/psar.indicator.ts
@@ -1,6 +1,5 @@
 import { MinusDM } from '@indicators/directionalMovement/minusDM/minusDM.indicator';
 import { Candle } from '@models/types/candle.types';
-import Big from 'big.js';
 import { Indicator } from '../../indicator';
 
 export class PSAR extends Indicator<'PSAR'> {
@@ -25,7 +24,7 @@ export class PSAR extends Indicator<'PSAR'> {
   }
 
   private calcSar(sar: number, ep: number, af: number) {
-    return +Big(ep).minus(sar).mul(af).plus(sar);
+    return (ep - sar) * af + sar;
   }
 
   public onNewCandle(candle: Candle) {
@@ -59,7 +58,7 @@ export class PSAR extends Indicator<'PSAR'> {
         this.result = this.sar;
         if (currentHigh > this.ep) {
           this.ep = currentHigh;
-          this.af = Math.min(+Big(this.af).plus(this.acceleration), this.maxAcceleration);
+          this.af = Math.min(this.af + this.acceleration, this.maxAcceleration);
         }
         this.sar = Math.min(this.calcSar(newSar, this.ep, this.af), prevLow, currentLow);
       }
@@ -75,7 +74,7 @@ export class PSAR extends Indicator<'PSAR'> {
         this.result = this.sar;
         if (currentLow < this.ep) {
           this.ep = currentLow;
-          this.af = Math.min(+Big(this.af).plus(this.acceleration), this.maxAcceleration);
+          this.af = Math.min(this.af + this.acceleration, this.maxAcceleration);
         }
         this.sar = Math.max(this.calcSar(newSar, this.ep, this.af), prevHigh, currentHigh);
       }

--- a/src/indicators/momentum/roc/roc.indicator.ts
+++ b/src/indicators/momentum/roc/roc.indicator.ts
@@ -1,7 +1,6 @@
 import { Indicator } from '@indicators/indicator';
 import { Candle } from '@models/types/candle.types';
 import { RingBuffer } from '@utils/array/ringBuffer';
-import Big from 'big.js';
 
 export class ROC extends Indicator<'ROC'> {
   private ringBuffer: RingBuffer<number>;
@@ -17,13 +16,7 @@ export class ROC extends Indicator<'ROC'> {
     this.ringBuffer.push(close);
     if (!this.ringBuffer.isFull()) return;
 
-    this.result =
-      oldest === 0
-        ? 0
-        : +Big(close)
-            .div(oldest ?? close)
-            .minus(1)
-            .times(100);
+    this.result = oldest === 0 ? 0 : (close / (oldest ?? close) - 1) * 100;
   }
 
   public getResult() {

--- a/src/indicators/momentum/roc/roc.test.ts
+++ b/src/indicators/momentum/roc/roc.test.ts
@@ -46,6 +46,6 @@ describe('ROC', () => {
     ${{ close: 9, open: 68, high: 69.94866467256739, low: 7.051335327432617, volume: 823 }}     | ${-89.53488372093024}
   `('should return $expected when candle close to $candle.close', ({ candle, expected }) => {
     roc.onNewCandle(candle);
-    expect(roc.getResult()).toBeCloseTo(expected, 13);
+    expect(roc.getResult()).toBeCloseTo(expected, 12);
   });
 });

--- a/src/indicators/momentum/stochastic/stochastic.indicator.ts
+++ b/src/indicators/momentum/stochastic/stochastic.indicator.ts
@@ -5,7 +5,6 @@ import { EMA } from '@indicators/movingAverages/ema/ema.indicator';
 import { SMA } from '@indicators/movingAverages/sma/sma.indicator';
 import { WMA } from '@indicators/movingAverages/wma/wma.indicator';
 import { Candle } from '@models/types/candle.types';
-import Big from 'big.js';
 
 const MOVING_AVERAGES = {
   sma: SMA,
@@ -64,12 +63,12 @@ export class Stochastic extends Indicator<'Stochastic'> {
     this.highs[this.idxFast] = candle.high;
     this.lows[this.idxFast] = candle.low;
     this.closes[this.idxFast] = candle.close;
-    this.idxFast = +Big(this.idxFast).plus(1).mod(this.fastKPeriod);
+    this.idxFast = (this.idxFast + 1) % this.fastKPeriod;
 
     const lowest = Math.min(...this.lows);
     const highest = Math.max(...this.highs);
-    const range = Big(highest).minus(lowest);
-    const rawK = range.eq(0) ? 0 : +Big(candle.close).minus(lowest).div(range).times(100);
+    const range = highest - lowest;
+    const rawK = range === 0 ? 0 : ((candle.close - lowest) / range) * 100;
 
     this.maSlowK.onNewCandle({ close: rawK } as Candle);
     const slowK = this.maSlowK.getResult();

--- a/src/indicators/momentum/williamsR/williamsR.indicator.ts
+++ b/src/indicators/momentum/williamsR/williamsR.indicator.ts
@@ -1,7 +1,6 @@
 import { Indicator } from '@indicators/indicator';
 import { Candle } from '@models/types/candle.types';
 import { RingBuffer } from '@utils/array/ringBuffer';
-import Big from 'big.js';
 
 export class WilliamsR extends Indicator<'WilliamsR'> {
   private ringBufferHigh: RingBuffer<number>;
@@ -27,7 +26,7 @@ export class WilliamsR extends Indicator<'WilliamsR'> {
     const lowest = this.ringBufferLow.min();
     const lastClose = this.ringBufferClose.last();
     // Williams %R = (Close - HighestHigh) / (HighestHigh - LowestLow) * 100
-    this.result = highest === lowest ? 0 : +Big(lastClose).minus(highest).div(Big(highest).minus(lowest)).times(100);
+    this.result = highest === lowest ? 0 : ((lastClose - highest) / (highest - lowest)) * 100;
   }
 
   public getResult() {

--- a/src/indicators/movingAverages/dema/dema.indicator.ts
+++ b/src/indicators/movingAverages/dema/dema.indicator.ts
@@ -1,6 +1,5 @@
 import { Indicator } from '@indicators/indicator';
 import { Candle } from '@models/types/candle.types';
-import Big from 'big.js';
 import { isNil } from 'lodash-es';
 import { EMA } from '../ema/ema.indicator';
 
@@ -21,7 +20,7 @@ export class DEMA extends Indicator<'DEMA'> {
     if (!isNil(innerRes)) {
       this.outer.onNewCandle({ close: innerRes } as Candle);
       const outerRes = this.outer.getResult();
-      if (!isNil(outerRes)) this.result = +Big(2).mul(innerRes).minus(outerRes);
+      if (!isNil(outerRes)) this.result = 2 * innerRes - outerRes;
     }
   }
 

--- a/src/indicators/movingAverages/ema/ema.indicator.ts
+++ b/src/indicators/movingAverages/ema/ema.indicator.ts
@@ -1,41 +1,40 @@
 import { INPUT_SOURCES } from '@indicators/indicator.const';
 import { Candle } from '@models/types/candle.types';
-import Big from 'big.js';
 import { Indicator } from '../../indicator';
 
 export class EMA extends Indicator<'EMA'> {
   private period: number;
-  private alpha: Big;
+  private alpha: number;
   private age: number;
-  private sum: Big;
-  private prevEma: Big;
+  private sum: number;
+  private prevEma: number;
   private getPrice: (candle: Candle) => number;
 
   constructor({ period = 30, src = 'close' }: IndicatorRegistry['EMA']['input'] = { period: 30, src: 'close' }) {
     super('EMA', null);
     this.period = period;
-    this.alpha = Big(2).div(Big(period).plus(1));
+    this.alpha = 2 / (period + 1);
     this.age = 0;
-    this.sum = Big(0);
-    this.prevEma = Big(0);
+    this.sum = 0;
+    this.prevEma = 0;
     this.getPrice = INPUT_SOURCES[src];
   }
 
   public onNewCandle(candle: Candle) {
     const price = this.getPrice(candle);
     if (this.age < this.period) {
-      this.sum = this.sum.plus(price);
+      this.sum += price;
       this.age++;
 
       if (this.age === this.period) {
-        this.prevEma = this.sum.div(this.period);
-        this.result = +this.prevEma;
+        this.prevEma = this.sum / this.period;
+        this.result = this.prevEma;
       }
       return;
     }
 
-    this.prevEma = Big(price).minus(this.prevEma).times(this.alpha).plus(this.prevEma);
-    this.result = +this.prevEma;
+    this.prevEma = (price - this.prevEma) * this.alpha + this.prevEma;
+    this.result = this.prevEma;
   }
 
   public getResult() {

--- a/src/indicators/movingAverages/sma/sma.indicator.ts
+++ b/src/indicators/movingAverages/sma/sma.indicator.ts
@@ -1,6 +1,5 @@
 import { INPUT_SOURCES } from '@indicators/indicator.const';
 import { Candle } from '@models/types/candle.types';
-import Big from 'big.js';
 import { Indicator } from '../../indicator';
 
 export class SMA extends Indicator<'SMA'> {
@@ -8,7 +7,7 @@ export class SMA extends Indicator<'SMA'> {
   private buffer: number[];
   private idx: number;
   private age: number;
-  private sum: Big;
+  private sum: number;
   private getPrice: (candle: Candle) => number;
 
   constructor({ period = 30, src = 'close' }: IndicatorRegistry['SMA']['input'] = {}) {
@@ -17,7 +16,7 @@ export class SMA extends Indicator<'SMA'> {
     this.buffer = [];
     this.idx = 0;
     this.age = 0;
-    this.sum = Big(0);
+    this.sum = 0;
     this.getPrice = INPUT_SOURCES[src];
   }
 
@@ -26,18 +25,18 @@ export class SMA extends Indicator<'SMA'> {
     // Warming up period
     if (this.age < this.period) {
       this.age++;
-      this.sum = this.sum.plus(price);
+      this.sum += price;
       this.buffer[this.idx] = price;
       this.idx = (this.idx + 1) % this.period;
-      if (this.age === this.period) this.result = +this.sum.div(this.period);
+      if (this.age === this.period) this.result = this.sum / this.period;
       return;
     }
 
-    this.sum = this.sum.minus(this.buffer[this.idx]).plus(price);
+    this.sum = this.sum - this.buffer[this.idx] + price;
     this.buffer[this.idx] = price;
     this.idx = (this.idx + 1) % this.period;
 
-    this.result = +this.sum.div(this.period);
+    this.result = this.sum / this.period;
   }
 
   public getResult() {

--- a/src/indicators/movingAverages/smma/smma.indicator.ts
+++ b/src/indicators/movingAverages/smma/smma.indicator.ts
@@ -1,6 +1,5 @@
 import { Indicator } from '@indicators/indicator';
 import { Candle } from '@models/types/candle.types';
-import Big from 'big.js';
 import { SMA } from '../sma/sma.indicator';
 
 export class SMMA extends Indicator<'SMMA'> {
@@ -29,11 +28,7 @@ export class SMMA extends Indicator<'SMMA'> {
       return;
     }
 
-    this.result = +Big(this.period)
-      .minus(1)
-      .mul(this.result ?? 0)
-      .add(candle.close)
-      .div(this.period);
+    this.result = ((this.period - 1) * (this.result ?? 0) + candle.close) / this.period;
   }
 
   public getResult() {

--- a/src/indicators/movingAverages/tema/tema.indicator.ts
+++ b/src/indicators/movingAverages/tema/tema.indicator.ts
@@ -1,5 +1,4 @@
 import { Candle } from '@models/types/candle.types';
-import Big from 'big.js';
 import { isNil } from 'lodash-es';
 import { Indicator } from '../../indicator';
 import { EMA } from '../ema/ema.indicator';
@@ -33,7 +32,7 @@ export class TEMA extends Indicator<'TEMA'> {
     const e3 = this.ema3.getResult();
     if (isNil(e3)) return;
 
-    this.result = +Big(3).times(e1).minus(Big(3).times(e2)).plus(e3);
+    this.result = 3 * e1 - 3 * e2 + e3;
   }
 
   public getResult() {

--- a/src/indicators/movingAverages/wilderSmoothing/wilderSmoothing.indicator.ts
+++ b/src/indicators/movingAverages/wilderSmoothing/wilderSmoothing.indicator.ts
@@ -1,41 +1,37 @@
 import { Indicator } from '@indicators/indicator';
 import { Candle } from '@models/types/candle.types';
-import Big from 'big.js';
 
 export class WilderSmoothing extends Indicator<'WilderSmoothing'> {
   private period: number;
   private age: number;
-  private sum: Big;
-  private prevSmoothed: Big;
+  private sum: number;
+  private prevSmoothed: number;
 
   constructor({ period }: IndicatorRegistry['WilderSmoothing']['input'] = { period: 14 }) {
     super('WilderSmoothing', null);
     this.period = period;
     this.age = 0;
-    this.sum = Big(0);
-    this.prevSmoothed = Big(0);
+    this.sum = 0;
+    this.prevSmoothed = 0;
   }
 
   public onNewCandle({ close }: Candle): void {
     // Warmup: accumulate first 'period' values for simple average
     if (this.age < this.period) {
-      this.sum = this.sum.plus(close);
+      this.sum += close;
       this.age++;
 
       // Once enough data, initialize smoothed value
       if (this.age === this.period) {
-        this.prevSmoothed = this.sum.div(this.period);
-        this.result = +this.prevSmoothed;
+        this.prevSmoothed = this.sum / this.period;
+        this.result = this.prevSmoothed;
       }
       return;
     }
 
     // Wilder's smoothing: (prev*(period-1) + close) / period
-    this.prevSmoothed = this.prevSmoothed
-      .times(this.period - 1)
-      .plus(close)
-      .div(this.period);
-    this.result = +this.prevSmoothed;
+    this.prevSmoothed = (this.prevSmoothed * (this.period - 1) + close) / this.period;
+    this.result = this.prevSmoothed;
   }
 
   public getResult() {

--- a/src/indicators/movingAverages/wma/wma.indicator.ts
+++ b/src/indicators/movingAverages/wma/wma.indicator.ts
@@ -1,6 +1,5 @@
 import { Indicator } from '@indicators/indicator';
 import { Candle } from '@models/types/candle.types';
-import Big from 'big.js';
 
 export class WMA extends Indicator<'WMA'> {
   private period: number;
@@ -13,9 +12,7 @@ export class WMA extends Indicator<'WMA'> {
     this.period = period;
     this.fifo = [];
     // divider = period * (period + 1) / 2
-    this.divider = +Big(this.period)
-      .mul(this.period + 1)
-      .div(2);
+    this.divider = (this.period * (this.period + 1)) / 2;
     this.age = 0;
   }
 
@@ -35,8 +32,8 @@ export class WMA extends Indicator<'WMA'> {
   }
 
   private computeWMA() {
-    const periodSum = this.fifo.reduce((res, price, i) => +Big(res).plus(Big(price).times(i + 1)), 0);
-    return +Big(periodSum).div(this.divider);
+    const periodSum = this.fifo.reduce((res, price, i) => res + price * (i + 1), 0);
+    return periodSum / this.divider;
   }
 
   public getResult() {

--- a/src/indicators/oscillators/ao/ao.indicator.ts
+++ b/src/indicators/oscillators/ao/ao.indicator.ts
@@ -1,7 +1,6 @@
 import { Indicator } from '@indicators/indicator';
 import { SMA } from '@indicators/movingAverages/sma/sma.indicator';
 import { Candle } from '@models/types/candle.types';
-import Big from 'big.js';
 import { isNil } from 'lodash-es';
 
 export class AO extends Indicator<'AO'> {
@@ -16,7 +15,7 @@ export class AO extends Indicator<'AO'> {
 
   public onNewCandle({ high, low }: Candle): void {
     // Typical price: midpoint of the bar
-    const hl2 = +Big(high).plus(low).div(2);
+    const hl2 = (high + low) / 2;
 
     // Update fast and slow SMAs
     this.smaFast.onNewCandle({ close: hl2 } as Candle);

--- a/src/indicators/oscillators/cci/cci.indicator.ts
+++ b/src/indicators/oscillators/cci/cci.indicator.ts
@@ -3,7 +3,6 @@ import { Candle } from '@models/types/candle.types';
 import { RingBuffer } from '@utils/array/ringBuffer';
 import { hlc3 } from '@utils/candle/candle.utils';
 import { sum } from '@utils/math/math.utils';
-import Big from 'big.js';
 import { map } from 'lodash-es';
 
 export class CCI extends Indicator<'CCI'> {
@@ -22,15 +21,10 @@ export class CCI extends Indicator<'CCI'> {
     if (!this.ringBuffer.isFull()) return;
 
     const price = map(this.ringBuffer.toArray(), hlc3);
-    const mean = +Big(sum(price)).div(this.period);
-    const devSum = price.reduce((acc, v) => +Big(v).minus(mean).abs().plus(acc), 0);
-    const denom = +Big(devSum).div(this.period).times(0.015);
-    this.result =
-      denom === 0
-        ? 0
-        : +Big(price[this.period - 1])
-            .minus(mean)
-            .div(denom);
+    const mean = sum(price) / this.period;
+    const devSum = price.reduce((acc, v) => Math.abs(v - mean) + acc, 0);
+    const denom = (devSum / this.period) * 0.015;
+    this.result = denom === 0 ? 0 : (price[this.period - 1] - mean) / denom;
   }
 
   public getResult() {

--- a/src/indicators/oscillators/rsi/rsi.indicator.ts
+++ b/src/indicators/oscillators/rsi/rsi.indicator.ts
@@ -2,7 +2,6 @@ import { Indicator } from '@indicators/indicator';
 import { INPUT_SOURCES } from '@indicators/indicator.const';
 import { WilderSmoothing } from '@indicators/movingAverages/wilderSmoothing/wilderSmoothing.indicator';
 import { Candle } from '@models/types/candle.types';
-import Big from 'big.js';
 import { isNil } from 'lodash-es';
 
 export class RSI extends Indicator<'RSI'> {
@@ -25,7 +24,7 @@ export class RSI extends Indicator<'RSI'> {
       return;
     }
 
-    const change = +Big(price).minus(this.prevPrice);
+    const change = price - this.prevPrice;
     const gain = change > 0 ? change : 0;
     const loss = change < 0 ? -change : 0;
 
@@ -36,8 +35,8 @@ export class RSI extends Indicator<'RSI'> {
     const avgLoss = this.wilderLoss.getResult();
 
     if (!isNil(avgGain) && !isNil(avgLoss)) {
-      const total = +Big(avgGain).plus(avgLoss);
-      this.result = total === 0 ? 0 : +Big(avgGain).div(total).times(100);
+      const total = avgGain + avgLoss;
+      this.result = total === 0 ? 0 : (avgGain / total) * 100;
     }
 
     this.prevPrice = price;

--- a/src/indicators/volatility/atrcd/atrcd.indicator.ts
+++ b/src/indicators/volatility/atrcd/atrcd.indicator.ts
@@ -1,6 +1,5 @@
 import { EMA } from '@indicators/movingAverages/ema/ema.indicator';
 import { Candle } from '@models/types/candle.types';
-import Big from 'big.js';
 import { isNil } from 'lodash-es';
 import { Indicator } from '../../indicator';
 import { ATR } from '../atr/atr.indicator';
@@ -41,17 +40,17 @@ export class ATRCD extends Indicator<'ATRCD'> {
     const slow = this.emaSlow.getResult();
 
     if (isNil(fast) || isNil(slow)) return;
-    const atrcdLine = Big(fast).minus(slow);
-    this.emaSignal.onNewCandle({ close: +atrcdLine } as Candle);
+    const atrcdLine = fast - slow;
+    this.emaSignal.onNewCandle({ close: atrcdLine } as Candle);
     const signalNum = this.emaSignal.getResult();
 
     if (isNil(signalNum)) return;
-    const hist = atrcdLine.minus(Big(signalNum));
+    const hist = atrcdLine - signalNum;
 
     this.result = {
-      atrcd: +atrcdLine,
+      atrcd: atrcdLine,
       signal: signalNum,
-      hist: +hist,
+      hist,
     };
   }
 

--- a/src/indicators/volatility/trueRange/trueRange.indicator.ts
+++ b/src/indicators/volatility/trueRange/trueRange.indicator.ts
@@ -1,6 +1,5 @@
 import { Indicator } from '@indicators/indicator';
 import { Candle } from '@models/types/candle.types';
-import Big from 'big.js';
 
 export class TrueRange extends Indicator<'TrueRange'> {
   private prevCandle?: Candle;
@@ -16,23 +15,22 @@ export class TrueRange extends Indicator<'TrueRange'> {
       return;
     }
 
-    // Convert current high, low and previous close to Big for precise arithmetic.
-    const currentHigh = Big(candle.high);
-    const currentLow = Big(candle.low);
-    const prevClose = Big(this.prevCandle.close);
+    const currentHigh = candle.high;
+    const currentLow = candle.low;
+    const prevClose = this.prevCandle.close;
 
     // Calculate the three components:
-    const range1 = currentHigh.minus(currentLow);
-    const range2 = currentHigh.minus(prevClose).abs();
-    const range3 = currentLow.minus(prevClose).abs();
+    const range1 = currentHigh - currentLow;
+    const range2 = Math.abs(currentHigh - prevClose);
+    const range3 = Math.abs(currentLow - prevClose);
 
     // Determine the true range as the maximum of the three values.
     let greatest = range1;
-    if (range2.gt(greatest)) greatest = range2;
-    if (range3.gt(greatest)) greatest = range3;
+    if (range2 > greatest) greatest = range2;
+    if (range3 > greatest) greatest = range3;
 
     // Set the indicator result.
-    this.result = +greatest;
+    this.result = greatest;
 
     // Update the previous candle for the next computation.
     this.prevCandle = candle;


### PR DESCRIPTION
## Summary
- refactor indicator math to use regular number operations instead of Big.js
- loosen ROC test precision

## Testing
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_685f61bd7a94832e8725e07e66e8d7cf