### PR TITLE
Remove Bigjs from candle utils

### DIFF
--- a/src/indicators/oscillators/cci/cci.test.ts
+++ b/src/indicators/oscillators/cci/cci.test.ts
@@ -46,6 +46,6 @@ describe('CCI', () => {
     ${{ close: 9, open: 68, high: 69.94866467256739, low: 7.051335327432617, volume: 823 }}     | ${-47.02295552367288}
   `('should return $expected when candle close to $candle.close', ({ candle, expected }) => {
     cci.onNewCandle(candle);
-    expect(cci.getResult()).toBeCloseTo(expected, 13);
+    expect(cci.getResult()).toBeCloseTo(expected, 12);
   });
 });

--- a/src/utils/candle/candle.utils.ts
+++ b/src/utils/candle/candle.utils.ts
@@ -1,13 +1,11 @@
 import { Candle } from '@models/types/candle.types';
 import { Undefined } from '@models/types/generic.types';
-import Big from 'big.js';
 import { addMinutes, differenceInMinutes, isBefore } from 'date-fns';
 import { filter, first, last, map } from 'lodash-es';
 
-export const hl2 = (candle: Candle): number => +Big(candle.high).plus(candle.low).div(2);
-export const hlc3 = (candle: Candle): number => +Big(candle.high).plus(candle.low).plus(candle.close).div(3);
-export const ohlc4 = (candle: Candle): number =>
-  +Big(candle.open).plus(candle.high).plus(candle.low).plus(candle.close).div(4);
+export const hl2 = (candle: Candle): number => (candle.high + candle.low) / 2;
+export const hlc3 = (candle: Candle): number => (candle.high + candle.low + candle.close) / 3;
+export const ohlc4 = (candle: Candle): number => (candle.open + candle.high + candle.low + candle.close) / 4;
 
 export const fillMissingCandles = (candles: Candle[]): Undefined<Candle[]> => {
   const firstCandleStart = first(candles)?.start;


### PR DESCRIPTION
## Summary
- refactor candle helpers to drop Big.js
- loosen CCI precision tests

## Testing
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_685f71672d58832ea56c2ba4ed9d4b7b