### PR TITLE
Fix order completed handler awaiting

### DIFF
--- a/src/plugins/trader/trader.ts
+++ b/src/plugins/trader/trader.ts
@@ -215,7 +215,7 @@ export class Trader extends Plugin {
     });
     this.order.on(ORDER_COMPLETED_EVENT, async () => {
       try {
-        this.handleOrderCompletedEvent(advice, id);
+        await this.handleOrderCompletedEvent(advice, id);
       } catch (err) {
         if (err instanceof Error) {
           error('trader', err.message);


### PR DESCRIPTION
## Summary
- ensure order completion waits for async handler

## Testing
- `bun run format:check`
- `bun run lint:check`
- `bun run type:check`
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_685f71d48260832e84b60d7e622cf735