### PR TITLE
Remove Big.js from core utilities

### DIFF
--- a/src/services/core/batcher/candleBatcher/candleBatcher.ts
+++ b/src/services/core/batcher/candleBatcher/candleBatcher.ts
@@ -1,4 +1,3 @@
-import Big from 'big.js';
 import { omit } from 'lodash-es';
 import { Candle } from '../../../../models/types/candle.types';
 import { CandleSize } from './candleBatcher.types';
@@ -32,7 +31,7 @@ export class CandleBatcher {
         high: Math.max(acc.high, curr.high),
         low: Math.min(acc.low, curr.low),
         close: curr.close,
-        volume: +Big(acc.volume).plus(curr.volume),
+        volume: acc.volume + curr.volume,
       }),
       base,
     );

--- a/src/services/core/batcher/candleBatcher/candlebatcher.test.ts
+++ b/src/services/core/batcher/candleBatcher/candlebatcher.test.ts
@@ -1,4 +1,3 @@
-import Big from 'big.js';
 import { compact, first, map, max, min } from 'lodash-es';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { Candle } from '../../../../models/types/candle.types';
@@ -125,7 +124,7 @@ describe('candleBatcher', () => {
       high: max([firstCandle?.high, secondCandle?.high]),
       low: min([firstCandle?.low, secondCandle?.low]),
       close: secondCandle?.close,
-      volume: +Big(firstCandle?.volume ?? 0).plus(secondCandle?.volume ?? 0),
+      volume: (firstCandle?.volume ?? 0) + (secondCandle?.volume ?? 0),
     };
     const result: (Candle | undefined)[] = [];
     result.push(candleBatcher.addSmallCandle(firstCandle));

--- a/src/services/core/candleManager/candleManager.ts
+++ b/src/services/core/candleManager/candleManager.ts
@@ -4,7 +4,6 @@ import { Trade } from '@models/types/trade.types';
 import { debug } from '@services/logger';
 import { resetDateParts, toISOString } from '@utils/date/date.utils';
 import { filterTradesByTimestamp } from '@utils/trade/trade.utils';
-import Big from 'big.js';
 import { dropRight, each, first, groupBy, last, map, max, mergeWith, min, pick, sortBy } from 'lodash-es';
 
 export class CandleManager {
@@ -57,7 +56,7 @@ export class CandleManager {
     each(trades, ({ price, amount }) => {
       candle.high = max([candle.high, price]) ?? 0;
       candle.low = min([candle.low, price]) ?? 0;
-      candle.volume = +Big(amount).plus(candle.volume);
+      candle.volume += amount;
     });
 
     return candle;


### PR DESCRIPTION
## Summary
- replace Big.js arithmetic in core services with native JS math
- update CandleBatcher tests

## Testing
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_685f740a89e4832ea7154a7eaed049d5