### PR TITLE
Add standard deviation to performance report

### DIFF
--- a/documentation/plugins/performance-analyzer.md
+++ b/documentation/plugins/performance-analyzer.md
@@ -46,6 +46,7 @@ Here are the metrics reported in the `performanceReport` event:
 | `market`                   | Market movement (start price vs end price) in percent.                             |
 | `alpha`                    | Strategy outperformance vs market.                                                 |
 | `sharpe`                   | Sharpe ratio based on return volatility.                                           |
+| `standardDeviation`        | Standard deviation of trade profits, used to measure volatility.                   |
 | `exposure`                 | % of time the strategy was in a trade.                                             |
 | `downside`                 | Measure of downside risk based on losing trades.                                   |
 | `trades`                   | Number of trades executed.                                                         |

--- a/documentation/plugins/performance-reporter.md
+++ b/documentation/plugins/performance-reporter.md
@@ -44,6 +44,7 @@ Each row in the CSV contains the following metrics:
 | `originalBalance`       | Starting portfolio balance                                                                      |
 | `currentBalance`        | Final portfolio balance                                                                         |
 | `sharpeRatio`           | Risk-adjusted return metric                                                                     |
+| `standardDeviation`     | Standard deviation of trade profits, used to measure volatility                                 |
 | `expectedDownside`      | Worst-case loss estimate                                                                        |
 | `ratioRoundtrip`        | Ratio of trades that completed a full buy/sell cycle                                            |
 | `worstMae`              | Maximum MAE observed across all roundtrips (percentage)                                         |

--- a/src/plugins/performanceAnalyser/performanceAnalyzer.test.ts
+++ b/src/plugins/performanceAnalyser/performanceAnalyzer.test.ts
@@ -412,6 +412,7 @@ describe('PerformanceAnalyzer', () => {
         relativeProfit: 20,
         relativeYearlyProfit: 811.1111111111111,
         sharpe: 230.3174603174603,
+        standardDeviation: 3.5,
         startBalance: 1000,
         startPrice: 100,
         startTime: toTimestamp('2020-01-01T00:00:00Z'),
@@ -474,6 +475,7 @@ describe('PerformanceAnalyzer', () => {
       const report = analyzer['calculateReportStatistics']();
 
       expect(report?.sharpe).toBe(0);
+      expect(report?.standardDeviation).toBe(0);
     });
 
     it('should set sharpe to 0 when there are no roundtrips', () => {
@@ -482,6 +484,7 @@ describe('PerformanceAnalyzer', () => {
       const report = analyzer['calculateReportStatistics']();
 
       expect(report?.sharpe).toBe(0);
+      expect(report?.standardDeviation).toBe(0);
     });
   });
 });

--- a/src/plugins/performanceAnalyser/performanceAnalyzer.ts
+++ b/src/plugins/performanceAnalyser/performanceAnalyzer.ts
@@ -169,8 +169,8 @@ export class PerformanceAnalyzer extends Plugin {
     const percentExposure = (this.exposure / differenceInMilliseconds(this.dates.end, this.dates.start)) * 100;
 
     const volatility = stdev(this.roundTrips.map(r => r.profit));
-    const sharpe =
-      !volatility || Number.isNaN(volatility) ? 0 : (relativeYearlyProfit - this.riskFreeReturn) / volatility;
+    const standardDeviation = Number.isNaN(volatility) ? 0 : volatility;
+    const sharpe = !standardDeviation ? 0 : (relativeYearlyProfit - this.riskFreeReturn) / standardDeviation;
 
     const tradeCount = this.trades > 2 ? this.trades - 2 : 1;
     const downsideLosses = this.losses.map(r => r.profit);
@@ -200,6 +200,7 @@ export class PerformanceAnalyzer extends Plugin {
       relativeProfit: relativeProfit,
       relativeYearlyProfit,
       sharpe,
+      standardDeviation,
       startBalance: this.start.balance,
       startPrice: this.startPrice,
       startTime: this.dates.start,

--- a/src/plugins/performanceAnalyser/performanceAnalyzer.types.ts
+++ b/src/plugins/performanceAnalyser/performanceAnalyzer.types.ts
@@ -45,6 +45,8 @@ export type Report = {
   startBalance: number;
   exposure: number;
   sharpe: number;
+  /** Standard deviation of roundtrip profits */
+  standardDeviation: number;
   downside: number;
   ratioRoundTrips: Nullable<number>;
   /**

--- a/src/plugins/performanceAnalyser/performanceAnalyzer.utils.ts
+++ b/src/plugins/performanceAnalyser/performanceAnalyzer.utils.ts
@@ -43,6 +43,7 @@ export const logFinalize = (report: Report, currency: string, enableConsoleTable
       originalBalance: `${formater.format(report.startBalance)} ${currency}`,
       currentbalance: `${formater.format(report.balance)} ${currency}`,
       sharpeRatio: report.sharpe,
+      standardDeviation: report.standardDeviation,
       expectedDownside: `${round(report.downside, 2, 'down')}%`,
       ratioRoundtrip: report.ratioRoundTrips === null ? 'N/A' : `${round(report.ratioRoundTrips, 2)}%`,
       worstMAE: `${round(report.worstMaxAdverseExcursion, 2, 'down')}%`,

--- a/src/plugins/performanceReporter/performanceReporter.test.ts
+++ b/src/plugins/performanceReporter/performanceReporter.test.ts
@@ -25,7 +25,7 @@ vi.mock('@services/configuration/configuration', () => ({
 }));
 
 const HEADER =
-  'id;pair;start time;end time;duration;exposure;start price;end price;market;alpha;yearly profit;total trades;original balance;current balance;sharpe ratio;expected downside;ratio roundtrip;worst mae\n';
+  'id;pair;start time;end time;duration;exposure;start price;end price;market;alpha;yearly profit;total trades;original balance;current balance;sharpe ratio;standard deviation;expected downside;ratio roundtrip;worst mae\n';
 
 const baseConfig = {
   name: 'PerformanceReporter',
@@ -48,6 +48,7 @@ const sampleReport: Report = {
   startBalance: 1000,
   balance: 1320,
   sharpe: 1.25,
+  standardDeviation: 2.5,
   downside: 0.08,
   ratioRoundTrips: 0.9,
   worstMaxAdverseExcursion: 0,
@@ -116,6 +117,7 @@ describe('PerformanceReporter', () => {
           '1,000 USDT',
           '1,320 USDT',
           '1.25',
+          '2.5',
           '0.08%',
           '0.9%',
           '0%',

--- a/src/plugins/performanceReporter/performanceReporter.ts
+++ b/src/plugins/performanceReporter/performanceReporter.ts
@@ -13,7 +13,7 @@ export class PerformanceReporter extends Plugin {
   private readonly formater: Intl.NumberFormat;
   private readonly filePath: string;
   private readonly header =
-    'id;pair;start time;end time;duration;exposure;start price;end price;market;alpha;yearly profit;total trades;original balance;current balance;sharpe ratio;expected downside;ratio roundtrip;worst mae\n';
+    'id;pair;start time;end time;duration;exposure;start price;end price;market;alpha;yearly profit;total trades;original balance;current balance;sharpe ratio;standard deviation;expected downside;ratio roundtrip;worst mae\n';
 
   constructor({ name, filePath, fileName }: PerformanceReporterConfig) {
     super(name);
@@ -39,6 +39,7 @@ export class PerformanceReporter extends Plugin {
         `${this.formater.format(report.startBalance)} ${this.currency}`,
         `${this.formater.format(report.balance)} ${this.currency}`,
         report.sharpe,
+        report.standardDeviation,
         `${round(report.downside, 2, 'down')}%`,
         report.ratioRoundTrips === null ? 'N/A' : `${round(report.ratioRoundTrips, 2, 'down')}%`,
         `${round(report.worstMaxAdverseExcursion, 2, 'down')}%`,


### PR DESCRIPTION
## Summary
- compute standard deviation of roundtrip profits in `PerformanceAnalyzer`
- include new metric in console table output
- output the metric in `PerformanceReporter` CSV
- document the new metric
- adjust tests for analyzer and reporter
- clarify doc description for standard deviation

## Testing
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_686465f86e0c832ea972c561c2a1ec8b