### PR TITLE
Fix strategy tests for internal import

### DIFF
--- a/src/plugins/tradingAdvisor/tradingAdvisor.test.ts
+++ b/src/plugins/tradingAdvisor/tradingAdvisor.test.ts
@@ -34,7 +34,6 @@ describe('TradingAdvisor', () => {
   const config = {
     name: 'TradingAdvisor',
     strategyName: 'DummyStrategy',
-    strategyPath: '@strategies/index',
   } satisfies TradingAdvisorConfiguration;
   const defaultAdvice: Advice = { id: 'advice-100', recommendation: 'short', date: toTimestamp('2020') };
   const defaultCandle: Candle = { close: 100, high: 150, low: 90, open: 110, start: toTimestamp('2025'), volume: 10 };
@@ -64,7 +63,6 @@ describe('TradingAdvisor', () => {
       const badAdvisor = new TradingAdvisor({
         name: 'TradingAdvisor',
         strategyName: 'NonExistentStrategy',
-        strategyPath: '@strategies/index',
       });
       await expect(() => badAdvisor['processInit']()).rejects.toThrowError(GekkoError);
     });


### PR DESCRIPTION
## Summary
- update TradingAdvisor tests to omit unused strategyPath
- adjust StrategyManager tests for new createStrategy signature
- add unit test covering custom path import

## Testing
- `bun run test`
- `bun run lint:check`


------
https://chatgpt.com/codex/tasks/task_e_686a31190584832e8d58a030de9d475e