### PR TITLE
Add bot service tests

### DIFF
--- a/src/services/bots/Bot.test.ts
+++ b/src/services/bots/Bot.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Bot } from './Bot';
+
+class TestBot extends Bot {
+  public checkUpdates = vi.fn().mockResolvedValue(undefined);
+}
+
+describe('Bot', () => {
+  let bot: TestBot;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    bot = new TestBot();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should call setInterval with checkUpdates when listen is called', () => {
+    const setIntervalSpy = vi.spyOn(global, 'setInterval');
+    bot.listen(200);
+    expect(setIntervalSpy).toHaveBeenCalledWith(bot.checkUpdates, 200);
+  });
+
+  it('should stop interval when close is called', async () => {
+    const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
+    bot.listen(100);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(bot.checkUpdates).toHaveBeenCalledTimes(1);
+
+    bot.close();
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(300);
+    expect(bot.checkUpdates).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/bots/telegram/TelegramBot.test.ts
+++ b/src/services/bots/telegram/TelegramBot.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi, Mock } from 'vitest';
+import { TelegramBot } from './TelegramBot';
+
+vi.mock('@services/fetcher/fetcher.service', () => ({
+  fetcher: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+const { fetcher } = await import('@services/fetcher/fetcher.service');
+
+describe('TelegramBot', () => {
+  let bot: TelegramBot;
+  const token = 'test-token';
+
+  beforeEach(() => {
+    bot = new TelegramBot(token);
+    vi.clearAllMocks();
+  });
+
+  it('fetchUpdates should return updates and update offset', async () => {
+    const updates = [
+      { update_id: 1, message: { text: 'a', chat: { id: 1 } } },
+      { update_id: 2, message: { text: 'b', chat: { id: 2 } } },
+    ];
+    (fetcher.get as Mock).mockResolvedValue({ ok: true, result: updates });
+    const result = await (bot as any).fetchUpdates();
+    expect(fetcher.get).toHaveBeenCalledWith({
+      url: `https://api.telegram.org/bot${token}/getUpdates?timeout=30&offset=1`,
+    });
+    expect(result).toEqual(updates);
+    expect((bot as any).offset).toBe(2);
+  });
+
+  it('fetchUpdates should return empty array when response not ok', async () => {
+    (fetcher.get as Mock).mockResolvedValue({ ok: false, result: [] });
+    const result = await (bot as any).fetchUpdates();
+    expect(result).toEqual([]);
+  });
+
+  it('sendMessage should call fetcher.post with correct args', async () => {
+    (fetcher.post as Mock).mockResolvedValue({});
+    await bot.sendMessage(10, 'hello');
+    expect(fetcher.post).toHaveBeenCalledWith({
+      url: `https://api.telegram.org/bot${token}/sendMessage`,
+      payload: { chat_id: 10, text: 'hello' },
+    });
+  });
+
+  describe('checkUpdates', () => {
+    it('should send messages for updates', async () => {
+      (fetcher.get as Mock).mockResolvedValue({
+        ok: true,
+        result: [{ update_id: 1, message: { text: 'hi', chat: { id: 3 } } }],
+      });
+      bot.sendMessage = vi.fn();
+      await (bot as any).checkUpdates();
+      expect(bot.sendMessage).toHaveBeenCalledWith(3, 'hi');
+    });
+
+    it('should process commands via handleCommand', async () => {
+      const handle = vi.fn().mockReturnValue('pong');
+      bot = new TelegramBot(token, handle);
+      (fetcher.get as Mock).mockResolvedValue({
+        ok: true,
+        result: [{ update_id: 1, message: { text: '/ping', chat: { id: 4 } } }],
+      });
+      bot.sendMessage = vi.fn();
+      await (bot as any).checkUpdates();
+      expect(handle).toHaveBeenCalledWith('/ping');
+      expect(bot.sendMessage).toHaveBeenCalledWith(4, 'pong');
+    });
+
+    it('should ignore updates without message text', async () => {
+      (fetcher.get as Mock).mockResolvedValue({ ok: true, result: [{ update_id: 1 }] });
+      bot.sendMessage = vi.fn();
+      await (bot as any).checkUpdates();
+      expect(bot.sendMessage).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for Bot service
- add unit tests for TelegramBot service

## Testing
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_68729eb4ba6c832eab566a2ca9bcdef2