### PR TITLE
fix: sort candles in ascending order

### DIFF
--- a/src/services/storage/sqlite.storage.ts
+++ b/src/services/storage/sqlite.storage.ts
@@ -66,7 +66,7 @@ export class SQLiteStorage extends Storage {
   public getCandles({ start, end }: Interval<EpochTimeStamp, EpochTimeStamp>): Candle[] {
     const query = this.db.query<Candle, SQLQueryBindings[]>(`
       SELECT * FROM ${this.table}
-      WHERE start BETWEEN $start AND $end;
+      WHERE start BETWEEN $start AND $end
       ORDER BY start ASC
     `);
     return query.all({ $start: start, $end: end });


### PR DESCRIPTION
## Summary
- ensure getCandles orders results by start ascending

## Testing
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_68a23be3c11c832e8dde13d3b86ba428