### PR TITLE
fix: process remaining Telegram updates

### DIFF
--- a/src/services/bots/telegram/TelegramBot.test.ts
+++ b/src/services/bots/telegram/TelegramBot.test.ts
@@ -68,6 +68,19 @@ describe('TelegramBot', () => {
       await (bot as any).checkUpdates();
       expect(bot.sendMessage).not.toHaveBeenCalled();
     });
+
+    it('should continue processing updates after one without text', async () => {
+      const handle = vi.fn().mockReturnValue('pong');
+      bot = new TelegramBot(token, handle);
+      (fetcher.get as Mock).mockResolvedValue({
+        ok: true,
+        result: [{ update_id: 1 }, { update_id: 2, message: { text: '/ping', chat: { id: 7 } } }],
+      });
+      bot.sendMessage = vi.fn();
+      await (bot as any).checkUpdates();
+      expect(handle).toHaveBeenCalledWith('/ping');
+      expect(bot.sendMessage).toHaveBeenCalledWith('pong');
+    });
     it('should ignore updates without command', async () => {
       (fetcher.get as Mock).mockResolvedValue({
         ok: true,

--- a/src/services/bots/telegram/TelegramBot.ts
+++ b/src/services/bots/telegram/TelegramBot.ts
@@ -37,7 +37,7 @@ export class TelegramBot extends Bot {
     debug('bot', `Received ${updates.length} ${pluralize('update', updates.length)} from Telegram Bot`);
     for (const update of updates) {
       const message = update.message;
-      if (!message || !isString(message.text)) return;
+      if (!message || !isString(message.text)) continue;
       const { text, chat } = message;
       const cmd = text;
       debug('bot', `Received command from Telegram Bot: "${cmd}"`);


### PR DESCRIPTION
## Summary
- ensure Telegram bot keeps processing updates even when one lacks text
- test that updates after a textless one are handled

## Testing
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_68a23b908b24832eb83b707c96c2b28a