### PR TITLE
docs: fix typo in importer guide

### DIFF
--- a/documentation/modes/importer.md
+++ b/documentation/modes/importer.md
@@ -52,7 +52,7 @@ GEKKO_LOG_LEVEL=info
 GEKKO_CONFIG_FILE_PATH=./config/importer.yml
 ```
 
-## Configuartion file example
+## Configuration file example
 
 ```yaml
 # ./config/importer.yml


### PR DESCRIPTION
## Summary
- fix typo in configuration heading for importer guide

## Testing
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_68b9b9b1ff94832e80f6851032417949