### PR TITLE
docs: remove installation verification step

### DIFF
--- a/documentation/introduction/getting-started.md
+++ b/documentation/introduction/getting-started.md
@@ -24,14 +24,6 @@ Before you begin, ensure you have the following installed:
    bun install
    ```
 
-3. Verify the installation:
-
-   ```bash
-   bun run gekko --version
-   ```
-
-   You should see the Gekko version output.
-
 ## Importing Data
 
 To import historical market data for backtesting:


### PR DESCRIPTION
## Summary
- drop installation verification step from getting started guide

## Testing
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_68b9b98f2480832ea3c213bbf1074a64