### PR TITLE
feat: add cumulative volume delta indicator

### DIFF
--- a/documentation/indicators/volume.md
+++ b/documentation/indicators/volume.md
@@ -12,6 +12,10 @@ OBV tracks cumulative buying and selling pressure by adding the volume when the 
 
 The Elder Force Index (EFI) measures the strength behind price movements by combining price change with trading volume. The raw force value `(close - previous close) * volume` can be smoothed with a moving average (EMA by default) to reduce noise. You can choose `ema`, `sma`, `dema`, or `wma` smoothing. The indicator returns both the raw force index and the smoothed value. Positive EFI values indicate buying pressure, while negative values highlight selling pressure.
 
+## **CVD (Cumulative Volume Delta)**
+
+CVD compares aggressive buying and selling volume on each candle. For every update, `delta = active - (total - active)` and the indicator returns this delta for the most recent candle without accumulation. The `source` parameter selects 'quote' (default) or 'base' volumes, using `quoteVolume`/`quoteVolumeActive` or `volume`/`volumeActive`. Missing values are treated as `0`.
+
 ---
 
 More volume indicators will be introduced in future releases.

--- a/src/indicators/index.ts
+++ b/src/indicators/index.ts
@@ -31,5 +31,6 @@ export * from './volume/adl/adl.indicator';
 export * from './volume/efi/efi.indicator';
 export * from './volume/mfi/mfi.indicator';
 export * from './volume/obv/obv.indicator';
+export * from './volume/cvd/cvd.indicator';
 export * from './volume/volumeProfile/volumeProfile.indicator';
 export * from './volume/vwap/vwap.indicator';

--- a/src/indicators/volume/cvd/cvd.indicator.ts
+++ b/src/indicators/volume/cvd/cvd.indicator.ts
@@ -1,0 +1,22 @@
+import { Candle } from '@models/candle.types';
+import { Indicator } from '../../indicator';
+
+export class CVD extends Indicator<'CVD'> {
+  private source: 'quote' | 'base';
+
+  constructor({ source = 'quote' }: IndicatorRegistry['CVD']['input'] = {}) {
+    super('CVD', null);
+    this.source = source;
+  }
+
+  public onNewCandle(candle: Candle): void {
+    const total = this.source === 'quote' ? (candle.quoteVolume ?? 0) : (candle.volume ?? 0);
+    const active = this.source === 'quote' ? (candle.quoteVolumeActive ?? 0) : (candle.volumeActive ?? 0);
+
+    this.result = active - (total - active);
+  }
+
+  public getResult() {
+    return this.result;
+  }
+}

--- a/src/indicators/volume/cvd/cvd.test.ts
+++ b/src/indicators/volume/cvd/cvd.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { Candle } from '@models/candle.types';
+import { CVD } from './cvd.indicator';
+
+describe('CVD', () => {
+  const seq: Candle[] = [
+    {
+      start: 1,
+      open: 1,
+      high: 1.1,
+      low: 0.9,
+      close: 1.05,
+      volume: 10,
+      volumeActive: 7,
+      quoteVolume: 100,
+      quoteVolumeActive: 60,
+    },
+    {
+      start: 2,
+      open: 1.05,
+      high: 1.15,
+      low: 0.95,
+      close: 1.1,
+      volume: 8,
+      volumeActive: 3,
+      quoteVolume: 80,
+      quoteVolumeActive: 25,
+    },
+    {
+      start: 3,
+      open: 1.1,
+      high: 1.2,
+      low: 1.0,
+      close: 1.15,
+      volume: 12,
+      volumeActive: 6,
+      quoteVolume: 120,
+      quoteVolumeActive: 70,
+    },
+    {
+      start: 4,
+      open: 1.15,
+      high: 1.25,
+      low: 1.05,
+      close: 1.2,
+      volume: 5,
+      quoteVolume: 50,
+    },
+  ];
+
+  it.each`
+    source     | candles | expected
+    ${'quote'} | ${seq}  | ${-50}
+    ${'base'}  | ${seq}  | ${-5}
+  `(
+    'computes CVD delta using $source',
+    ({ source, candles, expected }: { source: 'quote' | 'base'; candles: Candle[]; expected: number }) => {
+      const cvd = new CVD({ source });
+      candles.forEach(c => cvd.onNewCandle(c));
+      expect(cvd.getResult()).toBeCloseTo(expected, 10);
+    },
+  );
+});

--- a/src/indicators/volume/cvd/cvd.types.ts
+++ b/src/indicators/volume/cvd/cvd.types.ts
@@ -1,0 +1,7 @@
+declare global {
+  interface IndicatorRegistry {
+    CVD: { input?: { source?: 'quote' | 'base' }; output: number | null };
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- add CVD indicator with base/quote volume sources
- register CVD types and export
- document CVD volume indicator

## Testing
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_68b9bf71dee8832ea13d7e733f6647a5