### PR TITLE
feat(neural-network): add configurable layers

### DIFF
--- a/src/indicators/momentum/neuralNetwork/neuralNetwork.types.ts
+++ b/src/indicators/momentum/neuralNetwork/neuralNetwork.types.ts
@@ -1,8 +1,10 @@
+import type * as tf from '@tensorflow/tfjs-node';
+
 declare global {
   interface IndicatorRegistry {
     neuralNetwork: {
       input: {
-        hiddenLayers?: number[];
+        layers?: Array<{ name: keyof typeof tf.layers; [key: string]: unknown }>;
         training?: {
           learningRate?: number;
           batchSize?: number;


### PR DESCRIPTION
## Summary
- replace neural network hidden layer counts with explicit layer configs
- derive input depth from first layer inputShape and build model dynamically
- validate layer configuration with type guard

## Testing
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_68c55b513780832e99b12e2387460c95