### PR TITLE
refactor: streamline neural network training

### DIFF
--- a/src/indicators/momentum/neuralNetwork/neuralNetwork.types.ts
+++ b/src/indicators/momentum/neuralNetwork/neuralNetwork.types.ts
@@ -22,5 +22,7 @@ export type TrainingConfig = {
   optimizerName: keyof Train;
   learningRate: number;
   epochs: number;
+  loss: string;
+  verbose: number;
 };
 export type LayerConfig = Layers & { name: LayersKeys };


### PR DESCRIPTION
## Summary
- compile the neural network model with configurable loss
- streamline `learn` and `rehearse` by batching epochs and disposing tensors
- expose optional training verbosity for fit calls
- validate loss and verbose training options

## Testing
- `bun run lint:check`
- `bun run type:check`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_68c58577b10c832e8e3e926b0df04430