### PR TITLE
fix(utils): handle empty ring buffer in max/min

### DIFF
--- a/src/utils/array/ringBuffer.test.ts
+++ b/src/utils/array/ringBuffer.test.ts
@@ -60,6 +60,12 @@ describe('RingBuffer', () => {
     expect(rb.toArray()).toEqual([8, 9, 10]);
   });
   describe('min & max', () => {
+    it('should return NaN when buffer is empty', () => {
+      const rb = new RingBuffer<number>(3);
+      expect(rb.max()).toBeNaN();
+      expect(rb.min()).toBeNaN();
+    });
+
     it('should return correct values when buffer not full', () => {
       const rb = new RingBuffer<number>(5);
       [4, 1, 7].forEach(v => rb.push(v));

--- a/src/utils/array/ringBuffer.ts
+++ b/src/utils/array/ringBuffer.ts
@@ -44,7 +44,8 @@ export class RingBuffer<T> {
    * @returns The maximum number or `NaN` if T is not number or buffer is empty.
    */
   max() {
-    return isNumberArray(this.buffer) ? Math.max(...this.buffer) : NaN;
+    if (!isNumberArray(this.buffer) || this.buffer.length === 0) return NaN;
+    return Math.max(...this.buffer);
   }
 
   /**
@@ -52,7 +53,8 @@ export class RingBuffer<T> {
    * @returns The minimum number or `NaN` if T is not number or buffer is empty.
    */
   min() {
-    return isNumberArray(this.buffer) ? Math.min(...this.buffer) : NaN;
+    if (!isNumberArray(this.buffer) || this.buffer.length === 0) return NaN;
+    return Math.min(...this.buffer);
   }
 
   /**


### PR DESCRIPTION
## Summary
- avoid Math.max/Math.min on empty ring buffer and return NaN instead
- cover empty buffer behavior in ring buffer tests

## Testing
- `bun run lint:check`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_68c5e2ea9530832ea7218bb5b44e5d74