### PR TITLE
feat: implement sortino deviation calculation

### DIFF
--- a/documentation/plugins/performance-analyzer.md
+++ b/documentation/plugins/performance-analyzer.md
@@ -1,6 +1,6 @@
 # Performance Analyzer Plugin
 
-The **PerformanceAnalyzer** plugin is responsible for tracking and reporting the performance of a trading strategy over time. It listens to portfolio value changes and executed trades, calculates advanced performance metrics (Sharpe ratio, alpha, etc.), and emits performance reports after every trade and at the end of the run.
+The **PerformanceAnalyzer** plugin is responsible for tracking and reporting the performance of a trading strategy over time. It listens to portfolio value changes and executed trades, calculates advanced performance metrics (Sharpe ratio, Sortino ratio, alpha, etc.), and emits performance reports after every trade and at the end of the run.
 
 This plugin is useful for both backtests and live runs to evaluate how profitable and stable a strategy is.
 
@@ -45,7 +45,8 @@ Here are the metrics reported in the `performanceReport` event:
 | `relativeYearlyProfit`     | Projected yearly profit in percent.                                                |
 | `market`                   | Market movement (start price vs end price) in percent.                             |
 | `alpha`                    | Strategy outperformance vs market.                                                 |
-| `sharpe`                   | Sharpe ratio based on return volatility.                                           |
+| `sharpe`                   | Sharpe ratio based on total return volatility.                                     |
+| `sortino`                  | Sortino ratio, which only penalizes downside volatility from losing trades.        |
 | `standardDeviation`        | Standard deviation of trade profits, used to measure volatility.                   |
 | `exposure`                 | % of time the strategy was in a trade.                                             |
 | `downside`                 | Measure of downside risk based on losing trades.                                   |

--- a/documentation/plugins/performance-reporter.md
+++ b/documentation/plugins/performance-reporter.md
@@ -1,7 +1,7 @@
 # PerformanceReporter Plugin
 
-The **PerformanceReporter** plugin saves a structured CSV log of each completed backtest run's performance report.  
-It is ideal for strategy researchers and quant developers who want to automatically collect key backtest metrics over time, such as profit, Sharpe ratio, number of trades, etc.
+The **PerformanceReporter** plugin saves a structured CSV log of each completed backtest run's performance report.
+It is ideal for strategy researchers and quant developers who want to automatically collect key backtest metrics over time, such as profit, Sharpe ratio, Sortino ratio, number of trades, etc.
 
 By storing the results in a single CSV file, it enables batch testing and comparison workflows without needing manual copy-paste or screenshotting Gekko outputs.
 
@@ -43,7 +43,8 @@ Each row in the CSV contains the following metrics:
 | `amountOfTrades`        | Number of trades executed                                                                       |
 | `originalBalance`       | Starting portfolio balance                                                                      |
 | `currentBalance`        | Final portfolio balance                                                                         |
-| `sharpeRatio`           | Risk-adjusted return metric                                                                     |
+| `sharpeRatio`           | Risk-adjusted return metric that considers both upside and downside volatility                  |
+| `sortinoRatio`          | Risk-adjusted return metric that only considers downside volatility                             |
 | `standardDeviation`     | Standard deviation of trade profits, used to measure volatility                                 |
 | `expectedDownside`      | Worst-case loss estimate                                                                        |
 | `ratioRoundtrip`        | Ratio of trades that completed a full buy/sell cycle                                            |

--- a/src/plugins/performanceAnalyser/performanceAnalyzer.test.ts
+++ b/src/plugins/performanceAnalyser/performanceAnalyzer.test.ts
@@ -412,6 +412,7 @@ describe('PerformanceAnalyzer', () => {
         relativeProfit: 20,
         relativeYearlyProfit: 811.1111111111111,
         sharpe: 230.3174603174603,
+        sortino: 0,
         standardDeviation: 3.5,
         startBalance: 1000,
         startPrice: 100,
@@ -476,6 +477,7 @@ describe('PerformanceAnalyzer', () => {
 
       expect(report?.sharpe).toBe(0);
       expect(report?.standardDeviation).toBe(0);
+      expect(report?.sortino).toBe(0);
     });
 
     it('should set sharpe to 0 when there are no roundtrips', () => {
@@ -485,6 +487,108 @@ describe('PerformanceAnalyzer', () => {
 
       expect(report?.sharpe).toBe(0);
       expect(report?.standardDeviation).toBe(0);
+      expect(report?.sortino).toBe(0);
+    });
+
+    it('should calculate sortino ratio from downside deviation of losses', () => {
+      analyzer['roundTrips'] = [
+        {
+          id: 1,
+          pnl: 50,
+          profit: 5,
+          maxAdverseExcursion: 0,
+          entryAt: 0,
+          entryPrice: 0,
+          entryBalance: 0,
+          exitAt: 0,
+          exitPrice: 0,
+          exitBalance: 0,
+          duration: 0,
+        },
+        {
+          id: 2,
+          pnl: -20,
+          profit: -2,
+          maxAdverseExcursion: 0,
+          entryAt: 0,
+          entryPrice: 0,
+          entryBalance: 0,
+          exitAt: 0,
+          exitPrice: 0,
+          exitBalance: 0,
+          duration: 0,
+        },
+        {
+          id: 3,
+          pnl: -60,
+          profit: -6,
+          maxAdverseExcursion: 0,
+          entryAt: 0,
+          entryPrice: 0,
+          entryBalance: 0,
+          exitAt: 0,
+          exitPrice: 0,
+          exitBalance: 0,
+          duration: 0,
+        },
+      ];
+
+      analyzer['losses'] = [
+        {
+          id: 2,
+          profit: -2,
+          duration: 0,
+          entryAt: 0,
+          entryBalance: 0,
+          entryPrice: 0,
+          exitAt: 0,
+          exitBalance: 0,
+          exitPrice: 0,
+          maxAdverseExcursion: 0,
+          pnl: -2,
+        },
+        {
+          id: 3,
+          profit: -6,
+          duration: 0,
+          entryAt: 0,
+          entryBalance: 0,
+          entryPrice: 0,
+          exitAt: 0,
+          exitBalance: 0,
+          exitPrice: 0,
+          maxAdverseExcursion: 0,
+          pnl: -6,
+        },
+      ];
+
+      const report = analyzer['calculateReportStatistics']();
+
+      expect(report?.sortino).toBeCloseTo(403.05555555555554);
+    });
+
+    it('should set sortino to 0 when no losses are recorded', () => {
+      analyzer['roundTrips'] = [
+        {
+          id: 1,
+          pnl: 50,
+          profit: 5,
+          maxAdverseExcursion: 0,
+          entryAt: 0,
+          entryPrice: 0,
+          entryBalance: 0,
+          exitAt: 0,
+          exitPrice: 0,
+          exitBalance: 0,
+          duration: 0,
+        },
+      ];
+
+      analyzer['losses'] = [];
+
+      const report = analyzer['calculateReportStatistics']();
+
+      expect(report?.sortino).toBe(0);
     });
   });
 });

--- a/src/plugins/performanceAnalyser/performanceAnalyzer.ts
+++ b/src/plugins/performanceAnalyser/performanceAnalyzer.ts
@@ -176,6 +176,8 @@ export class PerformanceAnalyzer extends Plugin {
     const downsideLosses = this.losses.map(r => r.profit);
     const downside =
       downsideLosses.length > 0 ? Math.sqrt(this.trades / tradeCount) * percentile(downsideLosses, 0.25) : 0;
+    const downsideDeviation = downsideLosses.length ? stdev(downsideLosses) : 0;
+    const sortino = !downsideDeviation ? 0 : (relativeYearlyProfit - this.riskFreeReturn) / Math.abs(downsideDeviation);
 
     const positiveRoundtrips = this.roundTrips.filter(roundTrip => roundTrip.pnl > 0);
 
@@ -200,6 +202,7 @@ export class PerformanceAnalyzer extends Plugin {
       relativeProfit: relativeProfit,
       relativeYearlyProfit,
       sharpe,
+      sortino,
       standardDeviation,
       startBalance: this.start.balance,
       startPrice: this.startPrice,

--- a/src/plugins/performanceAnalyser/performanceAnalyzer.types.ts
+++ b/src/plugins/performanceAnalyser/performanceAnalyzer.types.ts
@@ -45,6 +45,7 @@ export type Report = {
   startBalance: number;
   exposure: number;
   sharpe: number;
+  sortino: number;
   /** Standard deviation of roundtrip profits */
   standardDeviation: number;
   downside: number;

--- a/src/plugins/performanceAnalyser/performanceAnalyzer.utils.ts
+++ b/src/plugins/performanceAnalyser/performanceAnalyzer.utils.ts
@@ -3,6 +3,7 @@ import { TradeCompleted } from '@models/tradeStatus.types';
 import { debug, info } from '@services/logger';
 import { toISOString } from '@utils/date/date.utils';
 import { round } from '@utils/math/round.utils';
+import { formatRatio } from '@utils/string/string.utils';
 import { formatDuration, intervalToDuration } from 'date-fns';
 import { ROUND } from './performanceAnalyzer.const';
 import { Report } from './performanceAnalyzer.types';
@@ -42,7 +43,8 @@ export const logFinalize = (report: Report, currency: string, enableConsoleTable
       amountOfTrades: report.trades,
       originalBalance: `${formater.format(report.startBalance)} ${currency}`,
       currentbalance: `${formater.format(report.balance)} ${currency}`,
-      sharpeRatio: report.sharpe,
+      sharpeRatio: formatRatio(report.sharpe),
+      sortinoRatio: formatRatio(report.sortino),
       standardDeviation: report.standardDeviation,
       expectedDownside: `${round(report.downside, 2, 'down')}%`,
       ratioRoundtrip: report.ratioRoundTrips === null ? 'N/A' : `${round(report.ratioRoundTrips, 2)}%`,

--- a/src/plugins/performanceReporter/performanceReporter.test.ts
+++ b/src/plugins/performanceReporter/performanceReporter.test.ts
@@ -25,7 +25,7 @@ vi.mock('@services/configuration/configuration', () => ({
 }));
 
 const HEADER =
-  'id;pair;start time;end time;duration;exposure;start price;end price;market;alpha;yearly profit;total trades;original balance;current balance;sharpe ratio;standard deviation;expected downside;ratio roundtrip;worst mae\n';
+  'id;pair;start time;end time;duration;exposure;start price;end price;market;alpha;yearly profit;total trades;original balance;current balance;sharpe ratio;sortino ratio;standard deviation;expected downside;ratio roundtrip;worst mae\n';
 
 const baseConfig = {
   name: 'PerformanceReporter',
@@ -48,6 +48,7 @@ const sampleReport: Report = {
   startBalance: 1000,
   balance: 1320,
   sharpe: 1.25,
+  sortino: 1.1,
   standardDeviation: 2.5,
   downside: 0.08,
   ratioRoundTrips: 0.9,
@@ -117,6 +118,7 @@ describe('PerformanceReporter', () => {
           '1,000 USDT',
           '1,320 USDT',
           '1.25',
+          '1.10',
           '2.5',
           '0.08%',
           '0.9%',

--- a/src/plugins/performanceReporter/performanceReporter.ts
+++ b/src/plugins/performanceReporter/performanceReporter.ts
@@ -5,6 +5,7 @@ import { Fs } from '@services/fs/fs.types';
 import { error } from '@services/logger';
 import { toISOString } from '@utils/date/date.utils';
 import { round } from '@utils/math/round.utils';
+import { formatRatio } from '@utils/string/string.utils';
 import { appendFileSync, existsSync, mkdirSync, statSync, writeFileSync } from 'fs';
 import path from 'path';
 import { performanceReporterSchema } from './performanceReporter.schema';
@@ -16,7 +17,7 @@ export class PerformanceReporter extends Plugin {
   private readonly filePath: string;
   private fs: Fs = { lockSync: defaultLockSync };
   private readonly header =
-    'id;pair;start time;end time;duration;exposure;start price;end price;market;alpha;yearly profit;total trades;original balance;current balance;sharpe ratio;standard deviation;expected downside;ratio roundtrip;worst mae\n';
+    'id;pair;start time;end time;duration;exposure;start price;end price;market;alpha;yearly profit;total trades;original balance;current balance;sharpe ratio;sortino ratio;standard deviation;expected downside;ratio roundtrip;worst mae\n';
 
   constructor({ name, filePath, fileName }: PerformanceReporterConfig) {
     super(name);
@@ -45,7 +46,8 @@ export class PerformanceReporter extends Plugin {
         report.trades,
         `${this.formater.format(report.startBalance)} ${this.currency}`,
         `${this.formater.format(report.balance)} ${this.currency}`,
-        report.sharpe,
+        formatRatio(report.sharpe),
+        formatRatio(report.sortino),
         report.standardDeviation,
         `${round(report.downside, 2, 'down')}%`,
         report.ratioRoundTrips === null ? 'N/A' : `${round(report.ratioRoundTrips, 2, 'down')}%`,

--- a/src/utils/string/string.test.ts
+++ b/src/utils/string/string.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { pluralize } from './string.utils';
+import { formatRatio, pluralize } from './string.utils';
 
 const cases: [string, number, string, string?][] = [
   ['cat', 0, 'cat'],
@@ -17,5 +17,25 @@ const cases: [string, number, string, string?][] = [
 describe('pluralize', () => {
   it.each(cases)('%s x %i → %s', (word, count, expected, explicit) => {
     expect(pluralize(word, count, explicit)).toBe(expected);
+  });
+});
+
+describe('formatRatio', () => {
+  it.each`
+    value        | expected
+    ${null}      | ${''}
+    ${undefined} | ${''}
+    ${NaN}       | ${''}
+    ${0}         | ${'0.00'}
+    ${0.004}     | ${'0.00'}
+    ${-0.004}    | ${'0.00'}
+    ${0.005}     | ${'0.01'}
+    ${-0.005}    | ${'-0.01'}
+    ${1}         | ${'1.00'}
+    ${1.234}     | ${'1.23'}
+    ${1.235}     | ${'1.24'}
+    ${-2.345}    | ${'-2.35'}
+  `('formatRatio($value) -> $expected', ({ value, expected }) => {
+    expect(formatRatio(value)).toBe(expected);
   });
 });

--- a/src/utils/string/string.utils.ts
+++ b/src/utils/string/string.utils.ts
@@ -23,3 +23,15 @@ export function pluralize(word: string, count: number, pluralForm?: string): str
   // default: just add “s”  (“cat” → “cats”)
   return `${word}s`;
 }
+
+const ratioFormatter = new Intl.NumberFormat('en-US', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+  useGrouping: false,
+});
+
+export function formatRatio(x: number | null | undefined): string {
+  if (x === null || x === undefined || Number.isNaN(x)) return '';
+  const rounded = Math.abs(x) < 0.005 ? 0 : x;
+  return ratioFormatter.format(rounded);
+}


### PR DESCRIPTION
## Summary
- compute downside deviation for the Sortino ratio only when the analyzer recorded downside losses to avoid unnecessary NaN handling

## Testing
- bun run test

------
https://chatgpt.com/codex/tasks/task_e_68cdb31e71f4832e8304ad1136f0c640